### PR TITLE
refactor: decouple CAN_Task from global hardware variables (Closes #8)

### DIFF
--- a/Application/Task/Inc/control_io.h
+++ b/Application/Task/Inc/control_io.h
@@ -68,6 +68,8 @@ typedef struct {
     int16_t wheel_current[2];   /* 驱动轮目标电流: [0]=左, [1]=右 */
     uint8_t chassis_situation;  /* 底盘状态 (CHASSIS_WEAK/CHASSIS_BALANCE) */
     uint8_t joint_init_done;    /* 关节初始化完成标志 */
+    uint8_t motor_active;       /* 电机激活标志: 0=关机, 1=运行 (由 Control_Task 根据遥控器开关填充) */
+    uint8_t reserved;           /* 预留对齐 */
     uint32_t seq;               /* 命令序号 */
     uint32_t tick;              /* 打包时间戳 */
 } motor_command_packet_t;

--- a/Application/Task/Src/CAN_Task.c
+++ b/Application/Task/Src/CAN_Task.c
@@ -1,60 +1,47 @@
 
 #include "cmsis_os.h"
 #include "CAN_Task.h"
-#include "Control_Task.h"
-#include "INS_Task.h"
 #include "Motor.h"
 #include "bsp_can.h"
-#include "Remote_Control.h"
-#include "Control_Task.h"
 #include "Image_Transmission.h"
-#include "control_io.h"//I/O边界：读取输出命令包
+#include "control_io.h"  /* I/O边界：读取 g_motor_cmd，不再直接访问 Control_Info/INS_Info/remote_ctrl */
 
+/**
+  * @brief  CAN_Task — 电机CAN通信线程 (1kHz)
+  * @note   本任务只通过 control_io.h 的 g_motor_cmd 获取控制指令，
+  *         不再直接依赖 Control_Task.h / INS_Task.h / Remote_Control.h。
+  */
  void CAN_Task(void const * argument)
 {
   TickType_t CAN_Task_SysTick = 0;
-//	 DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[0],Motor_Save_Zero_Position);
-//   osDelay(30);
-//	 DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[1],Motor_Save_Zero_Position);
-//   osDelay(30);
-//   DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[2],Motor_Save_Zero_Position);
-//   osDelay(30);
-//	 DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[3],Motor_Save_Zero_Position);
-//	
-
 
 	for(;;)
   {
-	
+
   CAN_Task_SysTick = osKernelSysTick();
 		if(DM_8009_Motor[0].Data.State != 1 && DM_8009_Motor[1].Data.State != 1 && DM_8009_Motor[2].Data.State != 1 &&  DM_8009_Motor[3].Data.State != 1)
 	{
-	//所有关节电机使能		
-	DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[0],Motor_Enable);
+		/* 关节电机未使能 → 发送使能命令 */
+	DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[0], Motor_Enable);
     osDelay(30);
-	 DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[1],Motor_Enable);
+	 DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[1], Motor_Enable);
   	osDelay(30);
-    DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[2],Motor_Enable);
+    DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[2], Motor_Enable);
     osDelay(30);
-	DM_Motor_Command(&FDCAN2_TxFrame,&DM_8009_Motor[3],Motor_Enable);
+	DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[3], Motor_Enable);
 	osDelay(30);
-	}else {		
-	 //当遥控器没拨到关机档时	
-	if(remote_ctrl.rc.s[1] == 3 || remote_ctrl.rc.s[1] == 1){
-// 		//测试转换器
-// 		//当关节电机没转到安全位置时
+	}else {
+	 /* 电机已使能，根据 g_motor_cmd.motor_active 决定发送模式 */
+	if(g_motor_cmd.motor_active != 0){
+		/* 关节初始化未完成 → 归零模式 */
  	 	if(g_motor_cmd.joint_init_done == 0){
-// 			//让关节电机位置归零
-	   		       DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[0],0,0,10.f,1.f,0);
-	   		       DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[1],0,0,10.f,1.f,0);
-        		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[2],0,0,10.f,1.f,0);	
-        		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[3],0,0,10.f,1.f,0);
- 			
-					
-			
-			
- 		 	//让轮子失能
- 			 FDCAN3_TxFrame.Header.Identifier = 0x200;					
+	   		       DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 10.f, 1.f, 0);
+	   		       DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 10.f, 1.f, 0);
+        		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 10.f, 1.f, 0);
+        		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 10.f, 1.f, 0);
+
+ 		 /* 初始化期间轮子失能 */
+ 			 FDCAN3_TxFrame.Header.Identifier = 0x200;
  		 	 FDCAN3_TxFrame.Data[0] = 0;
  		     FDCAN3_TxFrame.Data[1] = 0;
  		 	 FDCAN3_TxFrame.Data[2] = 0;
@@ -62,36 +49,30 @@
  		 	 FDCAN3_TxFrame.Data[4] = 0;
  		 	 FDCAN3_TxFrame.Data[5] = 0;
  		 	 USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
-// 	 //当整车初始化完成时
+
  	 }else{
-// 		//开始给电机发送数据
-// 					//让关节电机位置归零------测试用
-
-
-//测试平衡模式
- 		  DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[0],0,0,0,0,g_motor_cmd.joint_torque[0]);
- 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[1],0,0,0,0,g_motor_cmd.joint_torque[1]);
- 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[2],0,0,0,0,g_motor_cmd.joint_torque[2]);
- 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[3],0,0,0,0,g_motor_cmd.joint_torque[3]);
+		/* 正常运行模式：从 g_motor_cmd 获取电机指令 */
+ 		  DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 0, 0, g_motor_cmd.joint_torque[0]);
+ 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 0, 0, g_motor_cmd.joint_torque[1]);
+ 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 0, 0, g_motor_cmd.joint_torque[2]);
+ 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 0, 0, g_motor_cmd.joint_torque[3]);
  		FDCAN3_TxFrame.Header.Identifier = 0x200;
- 		  FDCAN3_TxFrame.Data[0] = (uint8_t)(g_motor_cmd.wheel_current[0]>>8);
+ 		  FDCAN3_TxFrame.Data[0] = (uint8_t)(g_motor_cmd.wheel_current[0] >> 8);
  		  FDCAN3_TxFrame.Data[1] = (uint8_t)(g_motor_cmd.wheel_current[0]);
- 		  FDCAN3_TxFrame.Data[2] = (uint8_t)(g_motor_cmd.wheel_current[1]>>8);
+ 		  FDCAN3_TxFrame.Data[2] = (uint8_t)(g_motor_cmd.wheel_current[1] >> 8);
  		  FDCAN3_TxFrame.Data[3] = (uint8_t)(g_motor_cmd.wheel_current[1]);
- 		  FDCAN3_TxFrame.Data[4] = (uint8_t)(0)>>8;//预留
- 		  FDCAN3_TxFrame.Data[5] = (uint8_t)(0);//预留
+ 		  FDCAN3_TxFrame.Data[4] = 0;
+ 		  FDCAN3_TxFrame.Data[5] = 0;
  		  USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
-//		 
 
 		}
-	//当要关机时	 
-	}else{	
-		//全部断电
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[0],0,0,0,0,0);
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[1],0,0,0,0,0);
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[2],0,0,0,0,0);	
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame,&DM_8009_Motor[3],0,0,0,0,0);	
-		  FDCAN3_TxFrame.Header.Identifier = 0x200;					
+	/* 关机状态：全部断电 */
+	}else{
+		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 0, 0, 0);
+		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 0, 0, 0);
+		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 0, 0, 0);
+		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 0, 0, 0);
+		  FDCAN3_TxFrame.Header.Identifier = 0x200;
 		  FDCAN3_TxFrame.Data[0] = 0;
 		  FDCAN3_TxFrame.Data[1] = 0;
 		  FDCAN3_TxFrame.Data[2] = 0;
@@ -100,18 +81,15 @@
 		  FDCAN3_TxFrame.Data[5] = 0;
 		  USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
 
-	
-	}	
 	}
-		
+	}
+
 	 if(CAN_Task_SysTick % 2 == 0){
-	 
-	 //500Hz发送 请保证所有任务osDelay(1)
-	 
-	 }	
+	 /* 预留500Hz子任务入口 */
+	 }
 		osDelay(1);
   }
- 
+
 }
 
 

--- a/Application/Task/Src/control_io.c
+++ b/Application/Task/Src/control_io.c
@@ -75,6 +75,10 @@ void Control_OutputPacket_Generate(const Control_Info_Typedef *ctrl,
     out->chassis_situation = (uint8_t)ctrl->Chassis_Situation;
     out->joint_init_done   = ctrl->Init.Joint_Init.IF_Joint_Init;
 
+    /* 电机激活标志: 遥控器开关 s[1]==3(初始化) 或 s[1]==1(高腿长) 时为 1，
+     * s[1]==2 或 0 时为 0。CAN_Task 用此值替代直接读取 remote_ctrl。*/
+    out->motor_active = (uint8_t)(remote_ctrl.rc.s[1] == 3 || remote_ctrl.rc.s[1] == 1);
+
     /* 序号和时间戳 */
     out->seq++;
     out->tick = osKernelSysTick();


### PR DESCRIPTION
## 做了什么
- `motor_command_packet_t` 新增 `motor_active` 标志
- `Control_OutputPacket_Generate()` 填充 `motor_active`（基于 `remote_ctrl.rc.s[1]`）
- `CAN_Task.c` 用 `g_motor_cmd.motor_active` 替代 `remote_ctrl.rc.s[1]`
- 移除 CAN_Task.c 中不再需要的 `#include "Control_Task.h"` / `#include "INS_Task.h"` / `#include "Remote_Control.h"`
- 清理无用的零位置保存注释代码

## 为什么做
解决 architecture_analysis_report.md §4.1 P0: CAN_Task 绕过 control_io.h 隔离层直接访问硬件全局变量。

## 测试
- [x] 编译验证待实车测试

## 修改文件
| 文件 | 改动 |
|------|------|
| Application/Task/Inc/control_io.h | +2 行 (新增 motor_active 字段) |
| Application/Task/Src/control_io.c | +4 行 (填充 motor_active) |
| Application/Task/Src/CAN_Task.c | 重写 65% (移除 4 个 include, 改用 g_motor_cmd)