### PR TITLE
fix: remaining optimizations (P4, P5, P9, P10 + .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,24 @@ node_modules/
 # STM32CubeMX generated
 *.bak
 *.printf
+
+# Keil MDK-ARM compilation artifacts
+*.crf
+*.d
+*.o
+*.dep
+*.axf
+*.htm
+*.lnp
+*.sct
+*.iex
+*.build_log.htm
+*.uvguix.*
+*.uvoptx
+*.scvd
+JLinkLog.txt
+JLinkSettings.ini
+*.lst
+COD_H7_Template/
+DebugConfig/
+RTE/

--- a/Application/Task/Inc/control_io.h
+++ b/Application/Task/Inc/control_io.h
@@ -74,6 +74,10 @@ typedef struct {
     uint32_t tick;              /* 打包时间戳 */
 } motor_command_packet_t;
 
+/* 编译期检查：确保输入快照适合栈分配 (1kHz 周期) */
+_Static_assert(sizeof(control_input_snapshot_t) <= 256,
+               "control_input_snapshot_t too large for 1kHz stack allocation");
+
 /* ======================== 函数声明 ======================== */
 
 /**

--- a/Application/Task/Src/mode_state_machine.c
+++ b/Application/Task/Src/mode_state_machine.c
@@ -8,12 +8,14 @@
 #include "mode_state_machine.h"
 #include "PID.h"
 
-/* ---- PID parameters ---- */
-static float PID_Leg_Length_F_Param[7]  = {1300.f, 1.f, 60000.f, 0.f, 0.f, 10.f, 100.f};
-static float PID_Leg_Roll_F_Param[7]    = {50.f,   0.f, 25.f,    0.f, 0.f, 0.1f, 50.f};
-static float PID_Leg_Coordinate_param[7]= {300.f,  0.f, 20.0f,  0.f, 0.f, 0.f,  50};
-static float PID_Yaw_P_pama[7]          = {4.4f,  0.f, 60.f,   0,   0,   200,  500};
-static float PID_Yaw_V_pama[7]          = {0.25f, 0,   0.4f,   0,   0,   200,  70};
+/* ---- PID parameters (KP, KI, KD, Alpha, Deadband, LimitIntegral, LimitOutput) ---- */
+#define PID_PARAM(Kp,Ki,Kd,A,Db,Li,Lo) { (Kp), (Ki), (Kd), (A), (Db), (Li), (Lo) }
+
+static float PID_Leg_Length_F_Param[7]  = PID_PARAM(1300.f, 1.f,  60000.f, 0.f, 0.f, 10.f, 100.f);
+static float PID_Leg_Roll_F_Param[7]    = PID_PARAM(50.f,   0.f,  25.f,    0.f, 0.f, 0.1f, 50.f);
+static float PID_Leg_Coordinate_param[7]= PID_PARAM(300.f,  0.f,  20.0f,  0.f, 0.f, 0.f,  50);
+static float PID_Yaw_P_pama[7]          = PID_PARAM(4.4f,   0.f,  60.f,   0,   0,   200,  500);
+static float PID_Yaw_V_pama[7]          = PID_PARAM(0.25f,  0,    0.4f,   0,   0,   200,  70);
 
 /* ---- PID instances ---- */
 PID_Info_TypeDef PID_Leg_Coordinate;

--- a/Application/Task/Src/sensor_fusion.c
+++ b/Application/Task/Src/sensor_fusion.c
@@ -13,17 +13,21 @@
 void SensorFusion_Measure_Update(Control_Info_Typedef *Control_Info,
                                   const control_input_snapshot_t *in)
 {
+    /* --- 共享 IMU 数据 (避免重复读取) --- */
+    float phi_shared     = -in->ins.Angle[2] - Control_Info->L_Leg_Info.Phi_Comp_Angle;
+    float phi_dot_shared = -in->ins.Gyro[0];
+
     /* --- 左腿姿态 --- */
-    Control_Info->L_Leg_Info.Measure.Phi     = -in->ins.Angle[2] - Control_Info->L_Leg_Info.Phi_Comp_Angle;
-    Control_Info->L_Leg_Info.Measure.Phi_dot = -in->ins.Gyro[0];
+    Control_Info->L_Leg_Info.Measure.Phi     = phi_shared;
+    Control_Info->L_Leg_Info.Measure.Phi_dot = phi_dot_shared;
     Control_Info->L_Leg_Info.Measure.Theta   = ((PI/2) - Control_Info->L_Leg_Info.Sip_Leg_Angle) - Control_Info->L_Leg_Info.Measure.Phi;
     Control_Info->L_Leg_Info.Measure.Theta_dot = (Control_Info->L_Leg_Info.X_J_Dot * arm_cos_f32(-Control_Info->L_Leg_Info.Measure.Theta)
                                                 + Control_Info->L_Leg_Info.Y_J_Dot * arm_sin_f32(-Control_Info->L_Leg_Info.Measure.Theta))
                                                / Control_Info->L_Leg_Info.Sip_Leg_Length;
 
     /* --- 右腿姿态 --- */
-    Control_Info->R_Leg_Info.Measure.Phi     = -in->ins.Angle[2] - Control_Info->L_Leg_Info.Phi_Comp_Angle;
-    Control_Info->R_Leg_Info.Measure.Phi_dot = -in->ins.Gyro[0];
+    Control_Info->R_Leg_Info.Measure.Phi     = phi_shared;
+    Control_Info->R_Leg_Info.Measure.Phi_dot = phi_dot_shared;
     Control_Info->R_Leg_Info.Measure.Theta   = (Control_Info->R_Leg_Info.Sip_Leg_Angle - (PI/2)) - Control_Info->R_Leg_Info.Measure.Phi;
     Control_Info->R_Leg_Info.Measure.Theta_dot = (-Control_Info->R_Leg_Info.X_J_Dot * arm_cos_f32(-Control_Info->R_Leg_Info.Measure.Theta)
                                                  + Control_Info->R_Leg_Info.Y_J_Dot * arm_sin_f32(-Control_Info->R_Leg_Info.Measure.Theta))

--- a/Application/Task/Src/vmc_kinematics.c
+++ b/Application/Task/Src/vmc_kinematics.c
@@ -37,6 +37,7 @@ void VMC_Calculate(Control_Info_Typedef *Control_Info)
     float L_S_Radicand = L_b * L_b - L_a * L_a * arm_sin_f32(L_M) * arm_sin_f32(L_M);
     float L_S;
     arm_sqrt_f32(L_S_Radicand, &L_S);
+    if (L_S < 1e-6f) L_S = 1e-6f;  /* 防止除零 */
     float L_t = L_a * arm_cos_f32(L_M) + L_S;
     float L_A = (L_a * L_t * arm_sin_f32(L_M)) / L_S;
 
@@ -59,6 +60,7 @@ void VMC_Calculate(Control_Info_Typedef *Control_Info)
     float R_S_Radicand = R_b * R_b - R_a * R_a * arm_sin_f32(R_M) * arm_sin_f32(R_M);
     float R_S;
     arm_sqrt_f32(R_S_Radicand, &R_S);
+    if (R_S < 1e-6f) R_S = 1e-6f;  /* 防止除零 */
     float R_t = R_a * arm_cos_f32(R_M) + R_S;
     float R_A = (R_a * R_t * arm_sin_f32(R_M)) / R_S;
 


### PR DESCRIPTION
## 5 项综合优化

| 优化 | 文件 | 说明 |
|------|------|------|
| **P5** 安全 | vmc_kinematics.c | arm_sqrt_f32 后添加 `if(S < 1e-6) S = 1e-6` 除零保护（左右腿各 1 处） |
| **P4** 性能 | sensor_fusion.c | 提取 `phi_shared`/`phi_dot_shared` 消除重复 IMU 读取 |
| **P9** 可读性 | mode_state_machine.c | `{Kp,Ki,Kd,...}` 裸数组 → `PID_PARAM(Kp,Ki,Kd,...)` 语义宏 |
| **P10** 安全 | control_io.h | 添加 `_Static_assert` 确保 control_input_snapshot_t ≤ 256 字节 |
| **chore** | .gitignore | 忽略 Keil 编译产物 (`.crf/.axf/.dep/.lnp/COD_H7_Template/`) |

## 文件改动
5 files (+43 / -10)