### PR TITLE
docs: babysitter-level comments for all 10 core files

### DIFF
--- a/Application/Task/Inc/control_io.h
+++ b/Application/Task/Inc/control_io.h
@@ -1,9 +1,29 @@
 /**
   ******************************************************************************
   * @file           : control_io.h
-  * @brief          : 控制任务 I/O 边界定义
-  * @description    : 定义输入快照和输出命令包结构体，
-  *                   将控制算法与硬件全局变量解耦。
+  * @brief          : 控制任务 I/O 边界 — 算法与硬件之间的"海关"
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   想象一个餐厅：后厨(硬件)不断产生食材(传感器数据)，前台(算法)需要
+  *   做菜(计算控制量)。这个文件就是"菜单"和"出餐口"——它规定：
+  *   1. 传感器数据必须按"菜单格式"(input_snapshot)打包好才能给算法
+  *   2. 算法算完的命令必须按"出餐格式"(motor_cmd)打包好才能给硬件
+  *
+  *   为什么要有这个"海关"？因为算法层如果直接伸手去后厨拿数据,
+  *   会出现"厨师正在切菜你去抢刀"的并发冲突——俗称数据竞争(Data Race)。
+  *
+  * 【核心职责】
+  *   1. 定义 input_snapshot  —— 每 1ms 给所有传感器"拍照"的格式
+  *   2. 定义 motor_cmd_packet —— 每 1ms 给电机下发命令的格式
+  *   3. 编译期大小检查 (_Static_assert) —— 防止快照太大撑爆栈
+  *
+  * 【前置知识】
+  *   - 结构体(struct): C语言的"数据包裹",把相关变量打包在一起
+  *   - 快照(Snapshot): 一瞬间拷贝所有传感器状态,之后只看这个拷贝
+  *   - CAN 总线: 机器人电机通信用的"网络电缆"
+  *
   ******************************************************************************
   */
 
@@ -16,86 +36,144 @@
 #include "INS_Task.h"
 #include "Control_Task.h"
 
-/* ======================== 输入快照 ======================== */
+/* ======================== 输入快照 (从硬件 → 算法) ======================== */
 
 /**
- * @brief 关节电机反馈快照 (对应 DM_8009_Motor[i].Data)
+ * @brief 关节电机反馈快照
+ *
+ * 🐣 通俗理解: 每条腿有2个关节(大腿+小腿),每个关节有一个DM8009电机。
+ *            电机每时每刻都在汇报"我现在转了多少度,转得多快,用了多大力"。
+ *            这个结构体就是这一瞬间的"体检数据"。
  */
 typedef struct {
-    float position;   /* 关节位置 (rad) */
-    float velocity;   /* 关节角速度 (rad/s) */
-    float torque;     /* 关节力矩反馈 (N·m) */
-    uint8_t state;    /* 电机状态字 */
+    /* [关节角度/位置] (弧度 rad) | 范围: [-π, π] | 电机转轴的实际位置,
+       正方向由机械安装决定,左小腿以"腿伸直"为 0 附近 */
+    float position;
+
+    /* [关节角速度] (弧度/秒 rad/s) | 范围: [-30, 30] | 转动快慢,
+       正值=逆时针转,负值=顺时针转 */
+    float velocity;
+
+    /* [关节输出力矩] (牛·米 N·m) | 范围: [-15, 15] | 电机实际输出的扭矩,
+       用于反算腿承受的力 (逆动力学) */
+    float torque;
+
+    /* [电机状态字] | 0=未使能, 1=已使能 | 类似"车门锁没锁" */
+    uint8_t state;
 } joint_snapshot_t;
 
 /**
- * @brief 驱动轮电机反馈快照 (对应 Chassis_Motor[i].Data)
+ * @brief 驱动轮电机反馈快照
+ *
+ * 🐣 通俗理解: 两条腿底部的轮子各有一个M3508电机,负责让机器人前进后退。
+ *            这里只取转速,因为轮子的控制是"电流模式"而非"位置模式"。
  */
 typedef struct {
-    int16_t velocity;  /* 轮速 (RPM) */
+    /* [轮速] (转/分钟 RPM) | 范围: [-8000, 8000] | 正值=向前转 */
+    int16_t velocity;
 } wheel_snapshot_t;
 
 /**
- * @brief 遥控器快照 (对应 remote_ctrl.rc)
+ * @brief 遥控器快照
+ *
+ * 🐣 通俗理解: 遥控器上每根摇杆和开关都有一个"通道号"。
+ *            ch[0]~ch[4]=5根摇杆的位置, s[0]~s[1]=2个开关的位置。
  */
 typedef struct {
-    int16_t ch[5];    /* 通道值 */
-    uint8_t s[2];     /* 开关值 */
+    int16_t ch[5];    /* 通道值 | 摇杆范围: [-660, 660] */
+    uint8_t s[2];     /* 开关值 | 0/1/2/3,对应不同档位 */
 } rc_snapshot_t;
 
 /**
- * @brief 控制任务输入快照
- * @note  每个控制周期开始时一次性采集，后续控制算法只读此结构体
+ * @brief 控制任务输入快照 — 整个算法的"视网膜"
+ *
+ * 🐣 这是全系统最重要的结构体之一！每 1ms 执行一次"拍照"：
+ *   - 把所有传感器(IMU/遥控器/4个关节电机/2个轮子电机)的数据
+ *     一秒不差地拷贝到这里
+ *   - 之后 16 步控制流水线只看这个快照,不再问硬件
+ *   - 这保证了"在同一时刻看到的世界是一致的"
+ *
+ * ⚠ 为什么大小不能超过 256 字节？
+ *   因为 1ms 一次、每次都在栈上分配。太大会栈溢出导致 HardFault。
  */
 typedef struct {
-    INS_Info_Typedef ins;       /* IMU 姿态/角速度/加速度 */
-    rc_snapshot_t rc;           /* 遥控器通道和开关 */
-    joint_snapshot_t joint[4];  /* 4个关节电机 (DM8009) */
-    wheel_snapshot_t wheel[2];  /* 2个驱动轮电机 */
-    float vbat;                 /* 电池电压 (V) */
-    uint32_t tick;              /* 采样时间戳 */
+    INS_Info_Typedef ins;       /* IMU 姿态: 欧拉角[3]+角速度[3]+加速度[3] */
+    rc_snapshot_t rc;           /* 遥控器: 摇杆+开关 */
+    joint_snapshot_t joint[4];  /* 4个关节电机: [0]左小腿 [1]左大腿 [2]右大腿 [3]右小腿 */
+    wheel_snapshot_t wheel[2];  /* 2个驱动轮: [0]左轮 [1]右轮 */
+    float vbat;                 /* [电池电压] (伏特 V) | 正常: [22, 25.2] | <22V需报警 */
+    uint32_t tick;              /* 采样时间戳 (FreeRTOS tick) */
 } control_input_snapshot_t;
 
-/* ======================== 输出命令包 ======================== */
+/* ======================== 输出命令包 (从算法 → 硬件) ======================== */
 
 /**
- * @brief 电机命令包
- * @note  Control_Task 每周期结束时打包，CAN_Task 只读此结构体
- *        关节顺序: [0]=左小腿, [1]=左大腿, [2]=右大腿, [3]=右小腿
+ * @brief 电机命令包 — 算法算完后下发给电机的"圣旨"
+ *
+ * 🐣 通俗理解: Control_Task 算了 16 步之后,得到了"4个关节各该用多大力,
+ *            2个轮子各该用多大电流"。把这个结果打包成一个"命令包",
+ *            CAN_Task 只负责把这个包发出去——它不管这个值是怎么算出来的。
+ *
+ * 📦 关节顺序 (一定要记住！):
+ *    [0]=左小腿 [1]=左大腿 [2]=右大腿 [3]=右小腿
  */
 typedef struct {
-    float joint_torque[4];      /* 关节目标力矩 (N·m) */
-    int16_t wheel_current[2];   /* 驱动轮目标电流: [0]=左, [1]=右 */
-    uint8_t chassis_situation;  /* 底盘状态 (CHASSIS_WEAK/CHASSIS_BALANCE) */
-    uint8_t joint_init_done;    /* 关节初始化完成标志 */
-    uint8_t motor_active;       /* 电机激活标志: 0=关机, 1=运行 (由 Control_Task 根据遥控器开关填充) */
-    uint8_t reserved;           /* 预留对齐 */
-    uint32_t seq;               /* 命令序号 */
-    uint32_t tick;              /* 打包时间戳 */
+    /* [关节目标力矩] (N·m) | 范围: [-15, 15] | 正值=伸腿,负值=收腿
+       ⚠ 如果此值超限, Joint_Tourgue_Calculate 中已有限幅保护 */
+    float joint_torque[4];
+
+    /* [驱动轮目标电流] (mA) | 范围: [-10000, 10000] | [0]=左轮 [1]=右轮
+       🐣 注意右轮取反了: 因为左右轮镜像安装,同时正转应该是反方向 */
+    int16_t wheel_current[2];
+
+    /* [底盘状态] 0=CHASSIS_WEAK(虚弱,关机), 1=CHASSIS_BALANCE(平衡,运行) */
+    uint8_t chassis_situation;
+
+    /* [关节初始化完成标志] 0=初始化中 1=已完成 | 初始化期间电机只做归零动作 */
+    uint8_t joint_init_done;
+
+    /* [电机激活标志] 0=全部断电, 1=正常运行
+       🐣 这个标志由 Control_Task 根据遥控器开关 s[1] 的值来设置:
+       s[1]==3(初始化) 或 s[1]==1(高腿长) → 激活=1
+       s[1]==2(关机)   或 s[1]==0         → 激活=0 */
+    uint8_t motor_active;
+
+    uint8_t reserved;           /* 预留对齐 (凑 4 字节对齐) */
+
+    uint32_t seq;               /* [命令序号] 每次打包+1, 用于检测丢包 */
+    uint32_t tick;              /* [打包时间戳] FreeRTOS tick */
 } motor_command_packet_t;
 
-/* 编译期检查：确保输入快照适合栈分配 (1kHz 周期) */
+/* 🔧 编译期安全检查:
+   如果这个断言失败,说明 control_input_snapshot_t 超过了 256 字节,
+   在 1kHz 频率下可能导致栈溢出。需要检查是否添加了太多不必要的字段。 */
 _Static_assert(sizeof(control_input_snapshot_t) <= 256,
                "control_input_snapshot_t too large for 1kHz stack allocation");
 
 /* ======================== 函数声明 ======================== */
 
 /**
- * @brief  从全局硬件变量一次性采集输入快照
- * @param  in: 输出的快照结构体指针
+ * @brief  "拍照" — 采集所有传感器的当前值
+ *
+ * 🐣 这是整个系统中唯一可以直接访问硬件全局变量的地方。
+ *    (DM_8009_Motor, Chassis_Motor, remote_ctrl, INS_Info 等)
+ *    其他所有代码都通过这个快照间接读取,从而避免数据竞争。
  */
 void Control_InputSnapshot_Update(control_input_snapshot_t *in);
 
 /**
- * @brief  从控制状态生成输出命令包
- * @param  ctrl: 控制状态结构体指针
- * @param  out:  输出的命令包指针
+ * @brief  "打包" — 把算好的控制量封装成电机命令包
+ *
+ * 🐣 只做赋值操作: 把 Control_Info 中的 SendValue 字段拷贝到 g_motor_cmd。
+ *    不做任何计算。CAN_Task 后续只读 g_motor_cmd。
  */
 void Control_OutputPacket_Generate(const Control_Info_Typedef *ctrl,
                                    motor_command_packet_t *out);
 
-/* ======================== 全局对象声明 ======================== */
+/* ======================== 全局对象 ======================== */
 
+/** g_motor_cmd — 唯一的电机命令出口
+ *  Control_Task 写入, CAN_Task 只读, 不需要锁 */
 extern motor_command_packet_t g_motor_cmd;
 
 #endif /* CONTROL_IO_H */

--- a/Application/Task/Src/CAN_Task.c
+++ b/Application/Task/Src/CAN_Task.c
@@ -1,95 +1,141 @@
+/**
+  ******************************************************************************
+  * @file           : CAN_Task.c
+  * @brief          : CAN 通信线程 — 把算好的电机指令发到 CAN 总线上
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   这是机器人的"传令兵"。它不参与任何计算——只负责从 g_motor_cmd
+  *   命令包里读出已经算好的电机指令,然后通过 CAN 总线发送给 6 个电机
+  *   (4个关节 DM8009 + 2个轮子 M3508)。
+  *
+  * 【核心职责】
+  *   1. 电机使能: 上电后等电机自检完成,发送使能命令
+  *   2. 初始化归零: 使能后关节未初始化时,发送位置归零命令
+  *   3. 正常运行: 从 g_motor_cmd 中读取力矩/电流,发送到 CAN 总线
+  *   4. 关机: 遥控器拨到关机档,全部电机扭矩清零
+  *
+  * 【前置知识】
+  *   - FDCAN: 灵活数据速率 CAN, STM32H7 的高速 CAN 外设
+  *   - DM_Motor_CAN_TxMessage: 大喵电机(妙德)的 CAN 协议发送函数
+  *   - g_motor_cmd: Control_Task 计算好的电机命令包(本线程只读)
+  *
+  *   📦 CAN 总线分布:
+  *   - FDCAN2: 4个 DM8009 关节电机 (ID 0,1,2,3)
+  *   - FDCAN3: 2个 M3508 驱动轮电机 (ID 0x201, 0x202)
+  *
+  ******************************************************************************
+  */
 
 #include "cmsis_os.h"
 #include "CAN_Task.h"
 #include "Motor.h"
 #include "bsp_can.h"
 #include "Image_Transmission.h"
-#include "control_io.h"  /* I/O边界：读取 g_motor_cmd，不再直接访问 Control_Info/INS_Info/remote_ctrl */
+#include "control_io.h"  /* I/O边界：只读取 g_motor_cmd */
 
 /**
-  * @brief  CAN_Task — 电机CAN通信线程 (1kHz)
-  * @note   本任务只通过 control_io.h 的 g_motor_cmd 获取控制指令，
-  *         不再直接依赖 Control_Task.h / INS_Task.h / Remote_Control.h。
-  */
- void CAN_Task(void const * argument)
+ * CAN_Task — 电机CAN通信线程 (1kHz)
+ *
+ * 🐣 注意: 本任务通过 osDelay(1) 也是 1kHz 频率,与 Control_Task 同频。
+ *   但它不依赖精确频率——只是"有命令就发,没命令就等着"。
+ *   g_motor_cmd.motor_active 决定了当前是初始化/运行/关机状态。
+ */
+void CAN_Task(void const * argument)
 {
-  TickType_t CAN_Task_SysTick = 0;
+    TickType_t CAN_Task_SysTick = 0;
 
-	for(;;)
-  {
+    for (;;) {
+        CAN_Task_SysTick = osKernelSysTick();
 
-  CAN_Task_SysTick = osKernelSysTick();
-		if(DM_8009_Motor[0].Data.State != 1 && DM_8009_Motor[1].Data.State != 1 && DM_8009_Motor[2].Data.State != 1 &&  DM_8009_Motor[3].Data.State != 1)
-	{
-		/* 关节电机未使能 → 发送使能命令 */
-	DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[0], Motor_Enable);
-    osDelay(30);
-	 DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[1], Motor_Enable);
-  	osDelay(30);
-    DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[2], Motor_Enable);
-    osDelay(30);
-	DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[3], Motor_Enable);
-	osDelay(30);
-	}else {
-	 /* 电机已使能，根据 g_motor_cmd.motor_active 决定发送模式 */
-	if(g_motor_cmd.motor_active != 0){
-		/* 关节初始化未完成 → 归零模式 */
- 	 	if(g_motor_cmd.joint_init_done == 0){
-	   		       DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 10.f, 1.f, 0);
-	   		       DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 10.f, 1.f, 0);
-        		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 10.f, 1.f, 0);
-        		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 10.f, 1.f, 0);
+        /* 🐣 步骤1: 检查电机是否已使能
+           DM8009 电机的 State 字段: 0=未使能, 1=已使能
+           如果 4 个电机中有一个没使能 → 发送使能命令(一次性)
+           使能后 osDelay(30ms) 等待电机响应,避免连续发送导致总线拥塞 */
+        if (DM_8009_Motor[0].Data.State != 1 && DM_8009_Motor[1].Data.State != 1 &&
+            DM_8009_Motor[2].Data.State != 1 && DM_8009_Motor[3].Data.State != 1) {
 
- 		 /* 初始化期间轮子失能 */
- 			 FDCAN3_TxFrame.Header.Identifier = 0x200;
- 		 	 FDCAN3_TxFrame.Data[0] = 0;
- 		     FDCAN3_TxFrame.Data[1] = 0;
- 		 	 FDCAN3_TxFrame.Data[2] = 0;
- 		 	 FDCAN3_TxFrame.Data[3] = 0;
- 		 	 FDCAN3_TxFrame.Data[4] = 0;
- 		 	 FDCAN3_TxFrame.Data[5] = 0;
- 		 	 USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
+            DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[0], Motor_Enable);
+            osDelay(30);
+            DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[1], Motor_Enable);
+            osDelay(30);
+            DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[2], Motor_Enable);
+            osDelay(30);
+            DM_Motor_Command(&FDCAN2_TxFrame, &DM_8009_Motor[3], Motor_Enable);
+            osDelay(30);
 
- 	 }else{
-		/* 正常运行模式：从 g_motor_cmd 获取电机指令 */
- 		  DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 0, 0, g_motor_cmd.joint_torque[0]);
- 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 0, 0, g_motor_cmd.joint_torque[1]);
- 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 0, 0, g_motor_cmd.joint_torque[2]);
- 		   DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 0, 0, g_motor_cmd.joint_torque[3]);
- 		FDCAN3_TxFrame.Header.Identifier = 0x200;
- 		  FDCAN3_TxFrame.Data[0] = (uint8_t)(g_motor_cmd.wheel_current[0] >> 8);
- 		  FDCAN3_TxFrame.Data[1] = (uint8_t)(g_motor_cmd.wheel_current[0]);
- 		  FDCAN3_TxFrame.Data[2] = (uint8_t)(g_motor_cmd.wheel_current[1] >> 8);
- 		  FDCAN3_TxFrame.Data[3] = (uint8_t)(g_motor_cmd.wheel_current[1]);
- 		  FDCAN3_TxFrame.Data[4] = 0;
- 		  FDCAN3_TxFrame.Data[5] = 0;
- 		  USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
+        } else {
+            /* 🐣 电机已使能,根据 g_motor_cmd.motor_active 决定发送模式:
+               motor_active=1 (s[1]=3/1): 初始化或运行
+               motor_active=0 (s[1]=2/0): 关机 */
 
-		}
-	/* 关机状态：全部断电 */
-	}else{
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 0, 0, 0);
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 0, 0, 0);
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 0, 0, 0);
-		 DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 0, 0, 0);
-		  FDCAN3_TxFrame.Header.Identifier = 0x200;
-		  FDCAN3_TxFrame.Data[0] = 0;
-		  FDCAN3_TxFrame.Data[1] = 0;
-		  FDCAN3_TxFrame.Data[2] = 0;
-		  FDCAN3_TxFrame.Data[3] = 0;
-		  FDCAN3_TxFrame.Data[4] = 0;
-		  FDCAN3_TxFrame.Data[5] = 0;
-		  USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
+            if (g_motor_cmd.motor_active != 0) {
 
-	}
-	}
+                /* 🐣 关节初始化未完成 → 归零模式
+                   joint_init_done=0 时, Control_Task 的状态机还在等 4 个关节归位。
+                   此期间发送"位置归零"命令(Position=0, KP=10, KD=1, Torque=0)
+                   驱动电机缓慢回到安装零位,同时轮子断电(防止乱转)。 */
+                if (g_motor_cmd.joint_init_done == 0) {
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 10.f, 1.f, 0);
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 10.f, 1.f, 0);
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 10.f, 1.f, 0);
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 10.f, 1.f, 0);
 
-	 if(CAN_Task_SysTick % 2 == 0){
-	 /* 预留500Hz子任务入口 */
-	 }
-		osDelay(1);
-  }
+                    /* 初始化期间轮子失能 (电流=0) */
+                    FDCAN3_TxFrame.Header.Identifier = 0x200;
+                    FDCAN3_TxFrame.Data[0] = 0;  FDCAN3_TxFrame.Data[1] = 0;
+                    FDCAN3_TxFrame.Data[2] = 0;  FDCAN3_TxFrame.Data[3] = 0;
+                    FDCAN3_TxFrame.Data[4] = 0;  FDCAN3_TxFrame.Data[5] = 0;
+                    USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
 
+                } else {
+                    /* 🐣 正常运行模式: 从 g_motor_cmd 获取电机指令 */
+
+                    /* 📦 关节电机: 以 MIT 模式发送(位置=0,速度=0,KP=0,KD=0)
+                       这意味着电机工作在"纯力矩模式"——只接受力矩指令,
+                       位置和速度闭环由外部(Control_Task)完成。
+                       力矩值来自 g_motor_cmd.joint_torque[4] */
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 0, 0, g_motor_cmd.joint_torque[0]);
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 0, 0, g_motor_cmd.joint_torque[1]);
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 0, 0, g_motor_cmd.joint_torque[2]);
+                    DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 0, 0, g_motor_cmd.joint_torque[3]);
+
+                    /* 📦 驱动轮电机: CAN ID=0x200, 数据格式:
+                       2个int16=4个字节,高字节在前
+                       Data[0:1] = 左轮电流高/低字节
+                       Data[2:3] = 右轮电流高/低字节
+                       Data[4:5] = 预留(0) */
+                    FDCAN3_TxFrame.Header.Identifier = 0x200;
+                    FDCAN3_TxFrame.Data[0] = (uint8_t)(g_motor_cmd.wheel_current[0] >> 8);
+                    FDCAN3_TxFrame.Data[1] = (uint8_t)(g_motor_cmd.wheel_current[0]);
+                    FDCAN3_TxFrame.Data[2] = (uint8_t)(g_motor_cmd.wheel_current[1] >> 8);
+                    FDCAN3_TxFrame.Data[3] = (uint8_t)(g_motor_cmd.wheel_current[1]);
+                    FDCAN3_TxFrame.Data[4] = 0;
+                    FDCAN3_TxFrame.Data[5] = 0;
+                    USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
+                }
+
+            } else {
+                /* 🐣 关机状态: 全部电机断电 (力矩=0)
+                   为什么要发力矩=0而不是不发？因为不发的话电机可能保持
+                   上一帧的力矩——如果不发0,机器人会"定住不动"而不是"松垮垮地倒下"。 */
+                DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[0], 0, 0, 0, 0, 0);
+                DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[1], 0, 0, 0, 0, 0);
+                DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[2], 0, 0, 0, 0, 0);
+                DM_Motor_CAN_TxMessage(&FDCAN2_TxFrame, &DM_8009_Motor[3], 0, 0, 0, 0, 0);
+
+                FDCAN3_TxFrame.Header.Identifier = 0x200;
+                FDCAN3_TxFrame.Data[0] = 0;  FDCAN3_TxFrame.Data[1] = 0;
+                FDCAN3_TxFrame.Data[2] = 0;  FDCAN3_TxFrame.Data[3] = 0;
+                FDCAN3_TxFrame.Data[4] = 0;  FDCAN3_TxFrame.Data[5] = 0;
+                USER_FDCAN_AddMessageToTxFifoQ(&FDCAN3_TxFrame);
+            }
+        }
+
+        /* 预留: 每 2 个 tick 一次的子任务 (500Hz) */
+        if (CAN_Task_SysTick % 2 == 0) {
+        }
+        osDelay(1);
+    }
 }
-
-

--- a/Application/Task/Src/Control_Task.c
+++ b/Application/Task/Src/Control_Task.c
@@ -1,44 +1,91 @@
 /**
   ******************************************************************************
   * @file           : Control_Task.c
-  * @brief          : 控制任务编排器 (1kHz)
-  * @description    : 将控制流水线委托给 5 个子模块:
-  *                   mode_state_machine → vmc_kinematics → lqr_controller
-  *                   → sensor_fusion → chassis_control
+  * @brief          : 控制任务编排器 (1kHz) — 机器人的"大脑皮层"
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   这是整个项目最核心的文件！它是机器人的"总司令"，每 1 毫秒执行一次
+  *   "思考循环"：看一眼世界(快照) → 做一连串计算 → 下达命令(电机指令)。
+  *   但这个文件本身**不做任何计算**——它只是"叫手下干活"的编排器(Orchestrator)。
+  *
+  * 【核心职责】
+  *   1. 初始化 PID 控制器参数 (一次性)
+  *   2. 每 1ms 循环一次,按固定顺序调度 11 步控制流水线
+  *   3. 流水线开始前采集快照,结束后打包命令
+  *   4. 每周期发送 4 通道调试数据到 VOFA+ 上位机
+  *
+  * 【运行频率】 1kHz = 每 1 毫秒执行一次
+  *   为什么这么快？因为机器人就像一根倒立的扫帚——平衡是"动态"的。
+  *   如果你 10ms 才反应一次(100Hz),那扫帚早就倒了。
+  *   1kHz = 人类感知不到延迟,对机器人来说已经够快。
+  *
+  * 【前置知识】
+  *   - FreeRTOS 的 osDelayUntil: 不是"睡 1ms"而是"等够 1ms",保证频率精准
+  *   - 控制周期: 传感器的采样→算法计算→电机指令下发,必须在 1ms 内完成
+  *   - 编排器模式: 自己不做具体工作,只调度子模块按顺序执行
+  *
   ******************************************************************************
   */
 
 #include "Control_Task.h"
-#include "cmsis_os.h"
-#include "bsp_uart.h"
-#include "Image_Transmission.h"
-#include "control_io.h"
+#include "cmsis_os.h"          /* FreeRTOS 操作系统接口 */
+#include "bsp_uart.h"          /* 串口驱动,用于 VOFA+ 调试遥测 */
+#include "Image_Transmission.h" /* 图传模块 */
+#include "control_io.h"         /* I/O 边界: 快照采集 + 命令打包 */
 
-#include "mode_state_machine.h"
-#include "vmc_kinematics.h"
-#include "lqr_controller.h"
-#include "chassis_control.h"
-#include "sensor_fusion.h"
+#include "mode_state_machine.h" /* 子模块1: 状态机 */
+#include "vmc_kinematics.h"     /* 子模块2: VMC 运动学 */
+#include "lqr_controller.h"     /* 子模块3: LQR 控制器 */
+#include "chassis_control.h"    /* 子模块4: 底盘控制 */
+#include "sensor_fusion.h"      /* 子模块5: 传感器融合 */
 
-/* ---- 全局控制状态 ---- */
+/* ====== 全局控制状态 ====== */
+/**
+ * Control_Info — 整个控制系统的"数据中心"
+ *
+ * 🐣 通俗理解: 这是机器人的"记忆"。里面记录了两条腿的物理参数、
+ *   当前状态、目标状态、PID 输出、LQR 输出……一切控制相关的数据
+ *   都存在这个结构体里。所有子模块都通过指针操作它。
+ *
+ *   初始化值(机械参数): 这些是"说明书上的参数"——腿有多长、杆长比多少。
+ *   如果是新车、新机械结构,这些值要改。
+ */
 Control_Info_Typedef Control_Info = {
+    /* [基础低腿长] (米 m) | 范围: [0.10, 0.25] | 低底盘模式下的腿长
+       🐣 腿长不是"骨头长度",而是从髋关节到脚底的虚拟长度 */
     .Base_Leg_Length_Low  = 0.14f,
+    /* [基础高腿长] (米 m) | 范围: [0.15, 0.35] | 高底盘模式下的腿长 */
     .Base_Leg_Length_High = 0.20f,
+
     .Roll = {
+        /* [两轮机械间距] (米 m) | 正常: 0.40~0.45 | 左右轮子中心之间的距离
+           🐣 这个值直接影响横滚补偿量: 间距越大 → 腿长差产生的横滚角越小 */
         .Distance_Two_Wheel = 0.4157f,
-        .Offset = 0.0f,
-        .Target_Angle = 0.0f,
+        .Offset = 0.0f,           /* IMU 角度补偿 */
+        .Target_Angle = 0.0f,     /* 目标横滚角=0 (保持水平) */
     },
+
     .L_Leg_Info = {
         .Biased = {
+            /* [大腿连杆长度] (米 m) | AH段长度 | 动力长后杆 */
             .L_Thigh_Link = 0.118114f,
+            /* [小腿连杆长度] (米 m) | AD段长度 | 动力短前杆 */
             .L_Calf_Link  = 0.100f,
+            /* [连杆长度比] K = AD/AH < 1 | 比值越小,同角度变化腿长变化越大 */
             .K = 0.465116f,
         },
+        /* [重力补偿] (牛顿 N) | 正常: 80~120 | 抵消机器人自重需要的推力
+           🐣 这个值≈机器人总重/2,因为两条腿各扛一半 */
         .Gravity_Compensation = 100.f,
+        /* [连杆重心补偿角度] (弧度 rad) | 用于修正连杆自身重量的影响 */
         .Link_Gravity_Compensation_Angle = 0.0f,
+        /* [陀螺仪角度补偿] (弧度 rad) | IMU 安装偏差的补偿值
+           🐣 当车平衡时陀螺仪读数非零,就用这个值补偿回去 */
         .Phi_Comp_Angle = -0.f,
     },
+
     .R_Leg_Info = {
         .Biased = {
             .L_Thigh_Link = 0.118114f,
@@ -46,64 +93,150 @@ Control_Info_Typedef Control_Info = {
             .K = 0.465116f,
         },
         .Gravity_Compensation = 100.f,
+        /* ⚠ 左右腿的补偿角度可能不同(机械不对称),所以这里写了 0.47 */
         .Link_Gravity_Compensation_Angle = 0.4701917f,
         .Phi_Comp_Angle = -0.f,
     },
 };
 
-/* 输入快照（每周期采集一次） */
+/* [输入快照] 每周期采集一次,存在全局区(非栈)方便调试 */
 static control_input_snapshot_t g_ctrl_input;
+
+/* [控制周期时间戳] 用于 osDelayUntil 保证 1kHz 精确频率 */
 TickType_t Control_Task_SysTick = 0;
 
+/**
+ * Control_Task — 控制周期主循环 (1kHz FreeRTOS 线程)
+ *
+ * 🐣 这个函数只做一件事: 按固定顺序调用 11 个子步骤,
+ *    每个步骤都委托给专门的子模块。你可以把它理解为
+ *    "机器人每秒做 1000 次下图的流程":
+ *
+ *  快照 ──▶ 状态机 ──▶ VMC运动学 ──▶ LQR增益 ──▶ 传感器融合
+ *                              │
+ *      底盘控制 ◀────────────────────┘
+ *         │
+ *      力/力矩计算 ──▶ LQR输出 ──▶ 关节力矩 ──▶ 打包命令 ──▶ 串口遥测
+ *
+ *  Step 0: 采集快照     — "拍照"当前世界状态
+ *  Step 1: 低电压检测   — 电池还有电吗？
+ *  Step 2: 模式更新     — 现在该平衡还是关机？
+ *  Step 3: 关节映射     — 电机角度→腿的角度
+ *  Step 4: VMC正运动学  — 复杂腿→简单棍子(L₀, φ₀)
+ *  Step 5: LQR增益更新  — 根据腿长查表得到最优推力系数
+ *  Step 6: 传感器融合   — IMU + 轮速计 → 6维状态向量
+ *  Step 7~10: 底盘控制  — 前进/转向/高度/横滚/腿长
+ *  Step 11: 力/力矩     — 算腿上的力和扭矩
+ *  Step 12: LQR输出     — u = -K·X 算出该用多大力
+ *  Step 13: 关节力矩    — 雅可比矩阵→4个电机的真实扭矩
+ *  Step 14: 打包命令    — 格式化为 g_motor_cmd
+ *  Step 15: 串口遥测    — 发调试数据到上位机
+ */
 void Control_Task(void const * argument)
 {
+    /* 🐣 第一步(只跑一次): 把所有 PID 控制器初始化好
+       类似"开机自检"——设置 Kp/Ki/Kd 参数、清零积分项 */
     Mode_Init(&Control_Info);
 
     for (;;) {
+        /* 🐣 osKernelSysTick() 返回"系统从开机到现在走了多少毫秒"
+           用来配合 osDelayUntil 实现精确的 1ms 定时 */
         Control_Task_SysTick = osKernelSysTick();
 
-        /* ===== 输入边界 ===== */
+        /* ====== 输入边界: 对所有传感器"拍照" ======
+           🐣 这一瞬间拷贝了所有硬件状态,后续14步都不会再碰硬件。
+           这就像是"闭上眼睛,凭记忆走路"——虽然记忆只有1ms前,但足够精确。 */
         Control_InputSnapshot_Update(&g_ctrl_input);
 
-        /* ===== 1. 状态机与模式 ===== */
+        /* ====== 第1步 低电压检测 ======
+           🐣 只看一眼电池电压,不报警不做任何事。
+           如果电压 < 22V 蜂鸣器会叫(已注释掉,简化实现) */
         Mode_Check_Low_Voltage(&Control_Info, &g_ctrl_input);
+
+        /* ====== 第2步 模式更新 ======
+           🐣 根据遥控器开关位置,决定机器人的状态:
+           s[1]=3 → 初始化模式,关节归位
+           s[1]=1 → 高腿长 + 平衡
+           s[1]=2 → 关机,所有电机关闭
+           初始化逻辑中 4 个关节必须同时到达安全位置才算"初始化完成" */
         Mode_Update(&Control_Info, &g_ctrl_input);
 
-        /* ===== 2. VMC 运动学 ===== */
+        /* ====== 第3步 关节角度映射 ======
+           🐣 电机汇报的是"转轴角度",但算法需要的是"大腿/小腿摆角"。
+           这里有坐标系转换: 左大腿 = PI + 关节1角度 (因为电机方向和腿方向差180°) */
         VMC_Joint_Angle_Offset(&Control_Info, &g_ctrl_input);
+
+        /* ====== 第4步 VMC正运动学 ======
+           🐣 核心步骤！把两条复杂的连杆腿变成两根简单的"虚拟棍子"。
+           输入: 大腿角度 + 小腿角度
+           输出: 虚拟腿长 L₀ + 虚拟腿倾角 φ₀
+           数学本质: 连杆正运动学 → 几何简化 */
         VMC_Calculate(&Control_Info);
 
-        /* ===== 3. LQR 控制器 ===== */
+        /* ====== 第5步 LQR增益更新 ======
+           🐣 腿长变了,K 矩阵就得跟着变。因为腿越长杠杆效应越大,需要的力越小。
+           K(L₀) = 多项式(L₀³, L₀², L₀, 常数),用霍纳法则快速计算 */
         LQR_K_Update(&Control_Info);
 
-        /* ===== 4. 传感器融合 ===== */
+        /* ====== 第6步 传感器融合 ======
+           🐣 IMU 给你倾角和角速度,轮速计给你底盘速度。但两个都不完美。
+           融合策略: 0.8×预测 + 0.2×测量 = 既快又稳的速度估计。
+           同时计算加速度(用于速度预测),并检测 CHASSIS_WEAK 状态清零所有状态量 */
         SensorFusion_Measure_Update(&Control_Info, &g_ctrl_input);
 
-        /* ===== 5. 底盘高层控制 ===== */
+        /* ====== 第7~10步 底盘高层控制 ======
+           🐣 四个独立的控制通道,按顺序执行: */
+        /* 7. 前进/后退/转向: 遥控器摇杆 → 速度目标 + 偏航力矩 */
         Chassis_Move_Control(&Control_Info, &g_ctrl_input);
+        /* 8. 高度切换: 遥控器开关 → 基础腿长目标 */
         Chassis_Height_Control(&Control_Info, &g_ctrl_input);
+        /* 9. 横滚补偿: IMU Roll角 → 左右腿长差 + 推力差 */
         Chassis_Roll_Control(&Control_Info, &g_ctrl_input);
+        /* 10.腿长控制: 基础+补偿 → 总目标腿长 → PID 计算推力 */
         Leg_Length_Control(&Control_Info);
 
-        /* ===== 6. VMC 力/力矩计算 ===== */
+        /* ====== 第11步 VMC力/力矩计算 ======
+           🐣 从关节电机反馈的力矩,反推虚拟腿受到的外力。
+           同时计算地面支持力 FN,判断腿是否着地(Support.Flag)。
+           为什么需要这个？空中的腿蹬不到地,再用力也是浪费。
+           所以检测到离地后,LQR 会把那条腿的推力清零。 */
         VMC_Measure_F_Tp_Calculate(&Control_Info);
 
-        /* ===== 7. LQR 输出 ===== */
+        /* ====== 第12步 LQR 状态误差 ======
+           🐣 X = Target - Measure。算出差了多少。
+           Target 一般都是0: "我希望不倾斜、不偏移、不移动"*/
         LQR_X_Update(&Control_Info);
+
+        /* ====== 第13步 LQR 控制输出 ======
+           🐣 u = -K·X: K 告诉"差这么多该用多大力",
+           X 告诉"现在差多少"。两者相乘得到最优控制力。
+           同时执行"防劈叉"PID(防止两条腿越走越散)和力矩综合。 */
         LQR_T_Tp_Calculate(&Control_Info);
 
-        /* ===== 8. 关节力矩输出 ===== */
+        /* ====== 第14步 关节力矩映射 ======
+           🐣 虚拟腿的推力 F 和扭矩 Tp → 4 个关节电机各该输出多少扭矩。
+           通过 2×2 雅可比矩阵转换,同时限幅防止力矩超标烧电机。 */
         VMC_Joint_Tourgue_Calculate(&Control_Info);
 
-        /* ===== 输出边界 ===== */
+        /* ====== 输出边界: 打包命令 ======
+           🐣 把所有 SendValue 拷贝到 g_motor_cmd。
+           CAN_Task 会另起线程,从这里读取并发给电机。 */
         Control_OutputPacket_Generate(&Control_Info, &g_motor_cmd);
 
-        /* ===== 调试遥测 ===== */
+        /* ====== 调试遥测 ======
+           🐣 向 VOFA+ 串口上位机发送 4 个 float 数据(JustFloat 协议)。
+           这 4 个通道可以在电脑上实时看波形:
+           [目标速度 | 右腿底盘速度 | 左腿底盘速度 | 底盘位置]
+           方便调试时观察控制效果 */
         USART_Vofa_Justfloat_Transmit(Control_Info.Target_Velocity,
                                        Control_Info.R_Leg_Info.Measure.Chassis_Velocity,
                                        Control_Info.L_Leg_Info.Measure.Chassis_Velocity,
                                        Control_Info.L_Leg_Info.Measure.Chassis_Position);
 
+        /* 🐣 osDelayUntil 不是"睡 1ms",而是"等到离上次执行刚好 1ms 为止"。
+           这样可以抵抗计算时间抖动,保证精确的 1kHz 频率。
+           如果某次计算花了 0.9ms,那这次只会等 0.1ms。
+           如果某次计算花了 1.1ms(超了!),那就立刻执行(不睡),频率会暂时下降。 */
         osDelayUntil(&Control_Task_SysTick, 1);
     }
 }

--- a/Application/Task/Src/INS_Task.c
+++ b/Application/Task/Src/INS_Task.c
@@ -1,16 +1,35 @@
-/* USER CODE BEGIN Header */
 /**
   ******************************************************************************
   * @file           : INS_Task.c
-  * @brief          : INS task
-  * @author         : GrassFan Wang
-  * @date           : 2025/01/22
-  * @version        : v1.0
-  ******************************************************************************
-  * @attention      : None
+  * @brief          : 惯性导航系统 — 把 BMI088 的陀螺仪+加速度计数据变成机身姿态
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   机器人身上挂着一个 BMI088 六轴 IMU 芯片。这个芯片每时每刻在告诉你:
+  *   - 角速度(Gyro): 你在绕哪个轴转多快 (°/s 或 rad/s)
+  *   - 加速度(Accel): 你在哪个方向承受多少 G 力 (m/s²)
+  *   但这个数据很"原始"——有噪声、有漂移。本文件的任务:
+  *   1. 读原始数据 → 做低通滤波(去毛刺)
+  *   2. 跑四元数 EKF 算法 → 姿态角(欧拉角)
+  *   3. 维护偏航角的"总圈数"(转超过360°不进位)
+  *   4. 控制 IMU 温度(用 PWM 加热)
+  *
+  * 【核心职责】
+  *   1. 读取 BMI088 原始数据
+  *   2. 二阶低通滤波 (加速度)
+  *   3. 四元数 EKF 姿态解算 → 欧拉角 Pitch/Yaw/Roll
+  *   4. 偏航总圈数累计
+  *   5. BMI088 温度 PID 控制
+  *
+  * 【前置知识】
+  *   - 欧拉角: Pitch=前后倾, Yaw=左右转, Roll=侧翻
+  *   - 四元数 EKF: 一个融合陀螺仪和加速度计的算法,让姿态既快又准
+  *   - 低通滤波: 把高频毛刺"磨平",但保留低频的有用信号
+  *   - 为什么要温度控制? BMI088 温度变化会影响零偏(传感器读的0不一定是真0)
+  *
   ******************************************************************************
   */
-/* USER CODE END Header */
 
 /* Includes ------------------------------------------------------------------*/
 #include "cmsis_os.h"
@@ -23,164 +42,157 @@
 #include "Quaternion.h"
 #include "bsp_pwm.h"
 
-/**
-  * @brief the structure that contains the information for the INS.
-  */
-INS_Info_Typedef INS_Info; 
+/* ====== 全局 IMU 状态 ======
+   🐣 INS_Info 是整个系统的"陀螺仪数据仓库"。
+   INS_Task 写入, Control_Task 通过快照读取。 */
+INS_Info_Typedef INS_Info;
 
-/**
-  * @brief the array that contains the data of LPF2p coefficients.
-  */
-static float INS_LPF2p_Alpha[3]={1.929454039488895f, -0.93178349823448126f, 0.002329458745586203f};
+/* ====== 二阶低通滤波器系数 ======
+   🐣 这三个系数决定了滤波器"有多磨"。值从 MATLAB 的 butter/filter designer 算出来。
+   不需要理解每个数字——你只需要知道: "加速度的毛刺被磨平了,姿态就不会抖"。 */
+static float INS_LPF2p_Alpha[3] = {1.929454039488895f, -0.93178349823448126f, 0.002329458745586203f};
 
-/**
-  * @brief the structure that contains the Information of accel LPF2p.
-  */
-LowPassFilter2p_Info_TypeDef INS_AccelPF2p[3];  
+/* 3 个二阶低通滤波器实例: 分别滤波 X/Y/Z 三轴的加速度 */
+LowPassFilter2p_Info_TypeDef INS_AccelPF2p[3];
 
-/**
-  * @brief the Initialize data of state transition matrix.
-  */
-static float QuaternionEKF_A_Data[36]={1, 0, 0, 0, 0, 0,
-                                       0, 1, 0, 0, 0, 0,
-                                       0, 0, 1, 0, 0, 0,
-                                       0, 0, 0, 1, 0, 0,
-                                       0, 0, 0, 0, 1, 0,
-                                       0, 0, 0, 0, 0, 1};
+/* ====== EKF 初始化矩阵 ====== */
+/* [状态转移矩阵 A] 初始为单位矩阵(6×6) */
+static float QuaternionEKF_A_Data[36] = {1,0,0,0,0,0, 0,1,0,0,0,0, 0,0,1,0,0,0,
+                                         0,0,0,1,0,0, 0,0,0,0,1,0, 0,0,0,0,0,1};
+/* [后验协方差矩阵 P] 最初设很大的值,表示"我还很不确定" */
+static float QuaternionEKF_P_Data[36] = {100000,0.1,0.1,0.1,0.1,0.1, 0.1,100000,0.1,0.1,0.1,0.1,
+                                         0.1,0.1,100000,0.1,0.1,0.1, 0.1,0.1,0.1,100000,0.1,0.1,
+                                         0.1,0.1,0.1,0.1,100,0.1, 0.1,0.1,0.1,0.1,0.1,100};
 
-/**
-  * @brief the Initialize data of posteriori covariance matrix.
-  */																
-static float QuaternionEKF_P_Data[36]= {100000, 0.1, 0.1, 0.1, 0.1, 0.1,
-                                        0.1, 100000, 0.1, 0.1, 0.1, 0.1,
-                                        0.1, 0.1, 100000, 0.1, 0.1, 0.1,
-                                        0.1, 0.1, 0.1, 100000, 0.1, 0.1,
-                                        0.1, 0.1, 0.1,   0.1,  100, 0.1,
-                                        0.1, 0.1, 0.1,   0.1,  0.1, 100};
-
-/**
-  * @brief the Initialize data of Temperature Control PID.
-  */																				
-static float TemCtrl_PID_Param[PID_PARAMETER_NUM]={1200,20,0,0,0,0,2000};
-
-/**
-  * @brief the structure that contains the Information of Temperature Control PID.
-  */
+/* ====== BMI088 温度控制 PID 参数 ====== */
+static float TemCtrl_PID_Param[7] = {1200, 20, 0, 0, 0, 0, 2000};
 PID_Info_TypeDef TempCtrl_PID;
 
-/**
- * @brief Initializes the INS_Task.
- */
+/* 前向声明 */
 static void INS_Task_Init(void);
-
-/**
-  * @brief  Control the BMI088 temperature
-  */
 static void BMI088_Temp_Control(float temp);
 
-/* USER CODE BEGIN Header_INS_Task */
 /**
-  * @brief  Function implementing the StartINSTask thread.
-  * @param  argument: Not used
-  * @retval None
-  */
-/* USER CODE END Header_INS_Task */
+ * INS_Task — IMU 姿态解算线程 (1kHz)
+ *
+ * 🐣 每 1ms 执行一次完整的姿态解算流程:
+ *   1. 读 BMI088 原始数据 (SPI 通信)
+ *   2. 加速度做二阶低通滤波 (去除高频噪声)
+ *   3. 四元数 EKF 更新 (融合陀螺仪和加速度 → 最优姿态)
+ *   4. 更新欧拉角 (弧度 + 度)
+ *   5. 偏航总圈数维护 (防止 Yaw 从 180° 突变到 -180°)
+ *   6. 每 5 次循环执行一次温度控制 (200Hz)
+ */
 void INS_Task(void const * argument)
 {
-  /* USER CODE BEGIN INS_Task */
-  TickType_t INS_Task_SysTick = 0;
+    TickType_t INS_Task_SysTick = 0;
 
+    /* 初始化: 低通滤波器 + 温度PID + EKF */
+    INS_Task_Init();
 
-	/* Initializes the INS_Task. */
-	INS_Task_Init();
-	
-  /* Infinite loop */
-  for(;;)
-  {
-    INS_Task_SysTick = osKernelSysTick();
-		
-		/* Update the BMI088 measurement */
-    BMI088_Info_Update(&BMI088_Info);
+    for (;;) {
+        INS_Task_SysTick = osKernelSysTick();
 
-    /* Accel measurement LPF2p */
-    INS_Info.Accel[0]   =   LowPassFilter2p_Update(&INS_AccelPF2p[0],BMI088_Info.Accel[0]);
-    INS_Info.Accel[1]   =   LowPassFilter2p_Update(&INS_AccelPF2p[1],BMI088_Info.Accel[1]);
-    INS_Info.Accel[2]   =   LowPassFilter2p_Update(&INS_AccelPF2p[2],BMI088_Info.Accel[2]);
-		
-    /* Update the INS gyro in radians */
-		INS_Info.Gyro[0]   =   BMI088_Info.Gyro[0];
-    INS_Info.Gyro[1]   =   BMI088_Info.Gyro[1];
-    INS_Info.Gyro[2]   =   BMI088_Info.Gyro[2];
-		
-		/* Update the QuaternionEKF */
-    QuaternionEKF_Update(&Quaternion_Info,INS_Info.Gyro,INS_Info.Accel,0.001f);
-		
-    memcpy(INS_Info.Angle,Quaternion_Info.EulerAngle,sizeof(INS_Info.Angle));
+        /* 🐣 步骤1: 读取 BMI088 原始数据
+           SPI 通信读取陀螺仪( °/s )和加速度计( m/s² )
+           数据保存在 BMI088_Info 全局结构体中 */
+        BMI088_Info_Update(&BMI088_Info);
 
-		/* Update the Euler angle in degrees. */
-    INS_Info.Pitch_Angle = Quaternion_Info.EulerAngle[IMU_ANGLE_INDEX_PITCH]*57.295779513f;
-    INS_Info.Yaw_Angle   = Quaternion_Info.EulerAngle[IMU_ANGLE_INDEX_YAW]   *57.295779513f;
-    INS_Info.Roll_Angle  = Quaternion_Info.EulerAngle[IMU_ANGLE_INDEX_ROLL]*57.295779513f;
-		
-		/* Update the yaw total angle */
-		if(INS_Info.Yaw_Angle - INS_Info.Last_Yaw_Angle < -180.f)
-		{
-			INS_Info.YawRoundCount++;
-		}
-		else if(INS_Info.Yaw_Angle - INS_Info.Last_Yaw_Angle > 180.f)
-		{
-			INS_Info.YawRoundCount--;
-		}
-		INS_Info.Last_Yaw_Angle = INS_Info.Yaw_Angle;
-		
-		INS_Info.Yaw_TolAngle = INS_Info.Yaw_Angle + INS_Info.YawRoundCount*360.f;
-		
-    /* Update the INS gyro in degrees */
-    INS_Info.Pitch_Gyro = INS_Info.Gyro[IMU_GYRO_INDEX_PITCH]*RadiansToDegrees;
-    INS_Info.Yaw_Gyro   = INS_Info.Gyro[IMU_GYRO_INDEX_YAW]*RadiansToDegrees;
-    INS_Info.Roll_Gyro  = INS_Info.Gyro[IMU_GYRO_INDEX_ROLL]*RadiansToDegrees;
-		
-		if(INS_Task_SysTick%5 == 0)
-		{
-			BMI088_Temp_Control(BMI088_Info.Temperature);
-		}
+        /* 🐣 步骤2: 加速度做二阶低通滤波
+           为什么只滤波加速度？加速度对振动非常敏感(走路时上下抖动),
+           而陀螺仪天生比较平滑——滤波后加速度的"假运动"被滤掉,
+           EKF 不会误以为"车在加速"而去错误修正姿态。 */
+        INS_Info.Accel[0] = LowPassFilter2p_Update(&INS_AccelPF2p[0], BMI088_Info.Accel[0]);
+        INS_Info.Accel[1] = LowPassFilter2p_Update(&INS_AccelPF2p[1], BMI088_Info.Accel[1]);
+        INS_Info.Accel[2] = LowPassFilter2p_Update(&INS_AccelPF2p[2], BMI088_Info.Accel[2]);
 
-    osDelayUntil(&INS_Task_SysTick,1);
-		
-  }
-  /* USER CODE END INS_Task */
+        /* 🐣 步骤3: 更新陀螺仪数据 (弧度/秒)
+           从 BMI088 原始数据(°/s)转换为弧度/秒 */
+        INS_Info.Gyro[0] = BMI088_Info.Gyro[0];
+        INS_Info.Gyro[1] = BMI088_Info.Gyro[1];
+        INS_Info.Gyro[2] = BMI088_Info.Gyro[2];
+
+        /* 🐣 步骤4: 四元数 EKF 更新
+           QuaternionEKF_Update 完成:
+           - 利用角速度预测下一时刻的四元数 (陀螺仪积分)
+           - 利用加速度修正四元数 (重力方向观测)
+           - 输出欧拉角 EulerAngle[3] (弧度) */
+        QuaternionEKF_Update(&Quaternion_Info, INS_Info.Gyro, INS_Info.Accel, 0.001f);
+
+        /* 🐣 步骤5: 拷贝欧拉角到 INS_Info
+           Angle[0]=Roll, Angle[1]=Pitch, Angle[2]=Yaw */
+        memcpy(INS_Info.Angle, Quaternion_Info.EulerAngle, sizeof(INS_Info.Angle));
+
+        /* 🐣 步骤6: 弧度 → 角度转换
+           57.295779513f = 180/π */
+        INS_Info.Pitch_Angle = Quaternion_Info.EulerAngle[IMU_ANGLE_INDEX_PITCH] * 57.295779513f;
+        INS_Info.Yaw_Angle   = Quaternion_Info.EulerAngle[IMU_ANGLE_INDEX_YAW]   * 57.295779513f;
+        INS_Info.Roll_Angle  = Quaternion_Info.EulerAngle[IMU_ANGLE_INDEX_ROLL]  * 57.295779513f;
+
+        /* 🐣 步骤7: 偏航总圈数维护
+           Yaw 输出的范围是 [-180°, 180°],当你转过 180° 时会跳到 -180°。
+           通过比较相邻两次的 Yaw 角,判断是否跨过了 ±180° 边界,
+           跨过了就 ±1 圈数。Yaw_TolAngle = 累计角度 = Yaw_Angle + 圈数×360°。
+           这样连续转 10 圈的累计角度是 3600°,而不是在 ±180° 之间来回跳。 */
+        if (INS_Info.Yaw_Angle - INS_Info.Last_Yaw_Angle < -180.f) {
+            INS_Info.YawRoundCount++;  /* 顺时针跨过+180° → 圈数+1 */
+        }
+        else if (INS_Info.Yaw_Angle - INS_Info.Last_Yaw_Angle > 180.f) {
+            INS_Info.YawRoundCount--;  /* 逆时针跨过-180° → 圈数-1 */
+        }
+        INS_Info.Last_Yaw_Angle = INS_Info.Yaw_Angle;
+        INS_Info.Yaw_TolAngle = INS_Info.Yaw_Angle + INS_Info.YawRoundCount * 360.f;
+
+        /* 🐣 步骤8: 角速度也转成"度/秒" (Control_Task 偏航PID 用) */
+        INS_Info.Pitch_Gyro = INS_Info.Gyro[IMU_GYRO_INDEX_PITCH] * RadiansToDegrees;
+        INS_Info.Yaw_Gyro   = INS_Info.Gyro[IMU_GYRO_INDEX_YAW]   * RadiansToDegrees;
+        INS_Info.Roll_Gyro  = INS_Info.Gyro[IMU_GYRO_INDEX_ROLL]  * RadiansToDegrees;
+
+        /* 🐣 步骤9: 每5个周期(200Hz)执行一次温度控制
+           温度控制的频率比姿态解算低,因为温度变化本身很慢 */
+        if (INS_Task_SysTick % 5 == 0) {
+            BMI088_Temp_Control(BMI088_Info.Temperature);
+        }
+
+        /* 🐣 等待 1ms (保证 1kHz 精确频率) */
+        osDelayUntil(&INS_Task_SysTick, 1);
+    }
 }
-//------------------------------------------------------------------------------
+
 /**
- * @brief Initializes the INS_Task.
+ * INS_Task_Init — 初始化低通滤波器、温度PID、四元数EKF
+ *
+ * 🐣 在 INS_Task 启动时只跑一次。
  */
 static void INS_Task_Init(void)
 {
-  /* Initializes the Second order lowpass filter  */
-  LowPassFilter2p_Init(&INS_AccelPF2p[0],INS_LPF2p_Alpha);
-  LowPassFilter2p_Init(&INS_AccelPF2p[1],INS_LPF2p_Alpha);
-  LowPassFilter2p_Init(&INS_AccelPF2p[2],INS_LPF2p_Alpha);
-	
-  /* Initializes the Temperature Control PID  */
-	PID_Init(&TempCtrl_PID,PID_POSITION,TemCtrl_PID_Param);
-	
-  /* Initializes the Quaternion EKF */
-	QuaternionEKF_Init(&Quaternion_Info,10.f, 0.001f, 1000000.f,QuaternionEKF_A_Data,QuaternionEKF_P_Data);
+    /* 初始化 3 个二阶低通滤波器(X/Y/Z轴) */
+    LowPassFilter2p_Init(&INS_AccelPF2p[0], INS_LPF2p_Alpha);
+    LowPassFilter2p_Init(&INS_AccelPF2p[1], INS_LPF2p_Alpha);
+    LowPassFilter2p_Init(&INS_AccelPF2p[2], INS_LPF2p_Alpha);
+
+    /* 初始化温度控制 PID */
+    PID_Init(&TempCtrl_PID, PID_POSITION, TemCtrl_PID_Param);
+
+    /* 初始化四元数 EKF
+       参数: 过程噪声10, dt=0.001s, 观测噪声1000000, 初始A/P矩阵 */
+    QuaternionEKF_Init(&Quaternion_Info, 10.f, 0.001f, 1000000.f, QuaternionEKF_A_Data, QuaternionEKF_P_Data);
 }
-//------------------------------------------------------------------------------
+
 /**
-  * @brief  Control the BMI088 temperature
-  * @param  temp  measure of the BMI088 temperature
-  * @retval none
-  */
+ * BMI088_Temp_Control — BMI088 温度控制
+ *
+ * 🐣 BMI088 的工作温度会影响其零偏(读数偏置)。稳定在 40°C 左右,数据最准。
+ *   PID 计算加热功率 → 通过 PWM 控制加热电阻。
+ */
 static void BMI088_Temp_Control(float Temp)
 {
-	PID_Calculate(&TempCtrl_PID,40.f,Temp);
-	
-	VAL_LIMIT(TempCtrl_PID.Output,-TempCtrl_PID.Param.LimitOutput,TempCtrl_PID.Param.LimitOutput);
+    /* 目标温度 40°C, PID 计算加热功率 */
+    PID_Calculate(&TempCtrl_PID, 40.f, Temp);
 
-	Heat_Power_Control((uint16_t)(TempCtrl_PID.Output));
+    /* ⚠ 限幅: 加热功率不能超过 PID 参数中设定的上限(2000) */
+    VAL_LIMIT(TempCtrl_PID.Output, -TempCtrl_PID.Param.LimitOutput, TempCtrl_PID.Param.LimitOutput);
+
+    /* 向 PWM 加热通道写入功率值 */
+    Heat_Power_Control((uint16_t)(TempCtrl_PID.Output));
 }
-//------------------------------------------------------------------------------
-
-

--- a/Application/Task/Src/chassis_control.c
+++ b/Application/Task/Src/chassis_control.c
@@ -1,7 +1,30 @@
 /**
   ******************************************************************************
   * @file           : chassis_control.c
-  * @brief          : High-level chassis motion control
+  * @brief          : 底盘高层控制 — 前进/转向/高度/横滚/腿长
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   这是机器人的"方向盘+刹车+油门+悬挂",负责把遥控器的操作
+  *   翻译成机器人的实际动作。四个独立的控制通道:
+  *   1. 前进后退: 摇杆→速度目标,用斜坡函数平滑过渡
+  *   2. 左右转向: 摇杆→偏航角度差,用串级PID控制
+  *   3. 高度切换: 开关→腿长目标,用斜坡函数平滑切换
+  *   4. 横滚补偿: IMU Roll角→左右腿长差+推力差,维持水平
+  *   5. 腿长控制: 总目标腿长→PID→推力+重力补偿
+  *
+  * 【核心职责】
+  *   1. Move_Control:    前进后退 + 偏航转向
+  *   2. Height_Control:  高/低底盘切换
+  *   3. Roll_Control:    横滚补偿 (腿长差+推力差)
+  *   4. Leg_Length:      腿长 PID + 重力补偿
+  *
+  * 【前置知识】
+  *   - f_Ramp_Calc(x, target, rate): 斜坡函数,让 x 平滑地趋向 target
+  *     rate 越大越"急促",越小越"慵懒"
+  *   - VAL_LIMIT(x, min, max): 限幅宏,把 x 夹在 [min, max] 之间
+  *
   ******************************************************************************
   */
 
@@ -10,86 +33,166 @@
 #include "Ramp.h"
 #include "arm_math.h"
 
-/* PID 引用 (定义在 mode_state_machine.c) */
 extern PID_Info_TypeDef PID_Leg_length_F[2];
 extern PID_Info_TypeDef PID_Leg_Roll_F;
 extern PID_Info_TypeDef PID_Yaw[2];
 
+/**
+ * Chassis_Move_Control — 前进后退 + 偏航转向
+ *
+ * 🐣 遥控器 ch[2] 和 ch[3] 控制移动:
+ *   ch[3]: 前进/后退摇杆 (范围: [-660, 660])
+ *   ch[2]: 转向摇杆 (范围: [-660, 660])
+ *
+ *   前进后退: 斜坡函数逐步改变目标速度,防止突然加速摔倒。
+ *   转向: 串级PID——外环把"角度差"转成"目标角速度",内环把"目标角速度"转成力矩。
+ */
 void Chassis_Move_Control(Control_Info_Typedef *Control_Info, const control_input_snapshot_t *in)
 {
+    /* [前进响应快慢] | 越小越慢/越平滑 | 0.001 = 非常缓慢的起步 */
     float K_Velocity = 0.001f;
+    /* [刹车响应快慢] | 比起步稍快,确保能快速停下 */
     float K_Brake    = 0.002f;
+    /* [转向响应] | 0.2 适中,太快会晃,太慢转不动 */
     float K_Yaw_P    = 0.2f;
 
-    /* 前进/后退 */
+    /* ====== 前进/后退 ======
+       🐣 当摇杆不在中心(ch[3]≠0)时:
+       - 用斜坡函数(ramp)修改目标速度: 当前值 → 摇杆值×0.00242
+       - 同时把底盘位置实时清零 → "我在移动,位置环不工作,只控速度"
+       当摇杆归零: 用斜坡函数"溜车"(慢慢归零),实现平滑刹车 */
     if (in->rc.ch[3] != 0) {
+        /* ch[3]范围[-660,660], 乘以0.00242 映射到约[-1.6, 1.6] m/s 的速度范围 */
         Control_Info->Target_Velocity = f_Ramp_Calc(Control_Info->Target_Velocity, -in->rc.ch[3] * 0.00242f, K_Velocity);
         Control_Info->L_Leg_Info.Measure.Chassis_Position = 0;
         Control_Info->R_Leg_Info.Measure.Chassis_Position = 0;
     } else {
         Control_Info->Target_Velocity = f_Ramp_Calc(Control_Info->Target_Velocity, 0, K_Brake);
     }
+    /* ⚠ 安全限速: 不管摇杆推多大,底盘速度≤1.6m/s (约5.8km/h) */
     VAL_LIMIT(Control_Info->Target_Velocity, -1.6f, 1.6f);
 
-    /* 偏航转向 */
+    /* ====== 偏航(左右转) ====== */
+    /* ch[2]的值映射到目标偏航角度(度),用斜坡函数平滑变化 */
     Control_Info->Yaw_Err = f_Ramp_Calc(Control_Info->Yaw_Err, (in->rc.ch[2] * RemoteToDegrees), K_Yaw_P);
+
+    /* 🐣 角度归一化: 把 [-360°, 360°] 映射到 [-180°, 180°]
+       因为"转 350°"等价于"反方向转10°",取近不取远 */
     if (Control_Info->Yaw_Err >= 180.f)
         Control_Info->Yaw_Err -= 360.f;
     else if (Control_Info->Yaw_Err <= -180.f)
         Control_Info->Yaw_Err += 360.f;
 
+    /* 🐣 串级PID: 外环(位置)输出作为内环(速度)的目标
+       PID_Yaw[0]: "我要转X度" → 算出"我该转多快"
+       PID_Yaw[1]: "我该转Y°/s" → 算出"我该用力矩Z" */
     PID_Calculate(&PID_Yaw[0], 0, Control_Info->Yaw_Err);
     PID_Calculate(&PID_Yaw[1], PID_Yaw[0].Output, in->ins.Yaw_Gyro);
+
+    /* 🐣 左右腿加相反方向的转向力矩 = 差速转向
+       左腿 +Turn_T, 右腿 -Turn_T → 左轮加速右轮减速 → 右转 */
     Control_Info->L_Leg_Info.Moment.Turn_T =  PID_Yaw[1].Output;
     Control_Info->R_Leg_Info.Moment.Turn_T = -PID_Yaw[1].Output;
 }
 
+/**
+ * Chassis_Height_Control — 高/低底盘切换
+ *
+ * 🐣 遥控器开关 s[1]==1 → 高腿长(越野模式), s[1]!=1 → 低腿长(公路模式)
+ *   K_Height = 0.0003 = 非常慢的切换速度,确保腿长变化不会导致机器摔倒
+ */
 void Chassis_Height_Control(Control_Info_Typedef *Control_Info, const control_input_snapshot_t *in)
 {
     float K_Height = 0.00030f;
     if (in->rc.s[1] == 1) {
+        /* 高腿长: 缓慢增加到 Control_Info.Base_Leg_Length_High (0.20m) */
         Control_Info->L_Leg_Info.Base_Leg_Length = f_Ramp_Calc(Control_Info->L_Leg_Info.Base_Leg_Length, Control_Info->Base_Leg_Length_High, K_Height);
         Control_Info->R_Leg_Info.Base_Leg_Length = f_Ramp_Calc(Control_Info->R_Leg_Info.Base_Leg_Length, Control_Info->Base_Leg_Length_High, K_Height);
     } else {
+        /* 低腿长: 缓慢降低到 Control_Info.Base_Leg_Length_Low (0.14m) */
         Control_Info->L_Leg_Info.Base_Leg_Length = f_Ramp_Calc(Control_Info->L_Leg_Info.Base_Leg_Length, Control_Info->Base_Leg_Length_Low, K_Height);
         Control_Info->R_Leg_Info.Base_Leg_Length = f_Ramp_Calc(Control_Info->R_Leg_Info.Base_Leg_Length, Control_Info->Base_Leg_Length_Low, K_Height);
     }
 }
 
+/**
+ * Chassis_Roll_Control — 横滚补偿
+ *
+ * 🐣 当机器人站在斜坡上,或一脚踩到高物体时,机身会左右倾斜(Roll)。
+ *   横滚补偿做两件事:
+ *   1. 几何补偿: 算出一条腿要多长才能把机身"撑平"
+ *   2. 力补偿: 用PID给"被压着的那条腿"更多推力
+ */
 void Chassis_Roll_Control(Control_Info_Typedef *Control_Info, const control_input_snapshot_t *in)
 {
+    /* [实际两腿长度差] (米 m) | 正值=左腿比右腿长 */
     Control_Info->Roll.Length_Diff = Control_Info->L_Leg_Info.Sip_Leg_Length - Control_Info->R_Leg_Info.Sip_Leg_Length;
-    Control_Info->Roll.Angle       = f_Ramp_Calc(Control_Info->Roll.Angle, (-in->ins.Angle[1] - 0.0291f), 0.003f);
+
+    /* [当前横滚角] (弧度 rad) | 一阶滤波: IMU 测量值 → 平滑后的角度
+       🐣 -0.0291rad 是 IMU 安装时的"零点偏移",扣掉才能得到真实的机身水平角 */
+    Control_Info->Roll.Angle = f_Ramp_Calc(Control_Info->Roll.Angle, (-in->ins.Angle[1] - 0.0291f), 0.003f);
+
+    /* [腿长差产生的横滚角正切值]
+       tan(Δθ) = 腿长差 ÷ 轮间距 */
     Control_Info->Roll.Tan_Length_Diff_Angle = Control_Info->Roll.Length_Diff / Control_Info->Roll.Distance_Two_Wheel;
-    Control_Info->Roll.Tan_Angle   = arm_sin_f32(Control_Info->Roll.Angle) / arm_cos_f32(Control_Info->Roll.Angle);
+
+    /* [机身横滚角的正切值]
+       tan(θ) = sin(θ)/cos(θ) */
+    Control_Info->Roll.Tan_Angle = arm_sin_f32(Control_Info->Roll.Angle) / arm_cos_f32(Control_Info->Roll.Angle);
+
+    /* [实际坡度角的正切值]
+       🐣 两角和的正切公式: tan(α+β) = (tanα+tanβ)/(1-tanα·tanβ)
+       α = 机身横滚角, β = 腿长差横滚角
+       需要这个公式是因为"腿长差实际上是让两轮子落在不同高度,等价于机身站在斜坡上" */
     Control_Info->Roll.Tan_Slope_Angle = (Control_Info->Roll.Tan_Angle + Control_Info->Roll.Tan_Length_Diff_Angle)
                                        / (1.0f - (Control_Info->Roll.Tan_Angle * Control_Info->Roll.Tan_Length_Diff_Angle));
 
+    /* [横滚补偿腿长] (米 m)
+       🐣 坡度角×轮间距÷2 = 需要哪条腿多长才能把机身"撑平"
+       左腿多伸长,右腿多缩短 > 这样机身就水平了 */
     Control_Info->L_Leg_Info.Roll_Leg_Length =  (Control_Info->Roll.Tan_Slope_Angle * Control_Info->Roll.Distance_Two_Wheel) / 2.0f;
     Control_Info->R_Leg_Info.Roll_Leg_Length = -(Control_Info->Roll.Tan_Slope_Angle * Control_Info->Roll.Distance_Two_Wheel) / 2.0f;
 
+    /* [横滚推力补偿]
+       🐣 PID 根据横滚角计算补偿力,左腿"往下压"右腿"往上顶",恢复水平
+       PID_Leg_Roll_F: Kp=50, Kd=25 → 快速但不过冲 */
     Control_Info->L_Leg_Info.Moment.Roll_F = -PID_Calculate(&PID_Leg_Roll_F, 0.f, Control_Info->Roll.Angle);
     Control_Info->R_Leg_Info.Moment.Roll_F =  PID_Calculate(&PID_Leg_Roll_F, 0.f, Control_Info->Roll.Angle);
 }
 
+/**
+ * Leg_Length_Control — 腿长控制 + 综合推力
+ *
+ * 🐣 把基础腿长(Base) + 横滚补偿(Roll) = 总目标腿长(Total)
+ *   然后用 PID 控制实际腿长趋近目标,同时加上重力补偿(抵消自重)。
+ */
 void Leg_Length_Control(Control_Info_Typedef *Control_Info)
 {
     float K_Length = 0.35f;
 
+    /* 总目标腿长 = 基础腿长 + 横滚补偿,用斜坡函数平滑变化 */
     Control_Info->L_Leg_Info.Total_Leg_Length = f_Ramp_Calc(Control_Info->L_Leg_Info.Total_Leg_Length,
         Control_Info->L_Leg_Info.Base_Leg_Length + Control_Info->L_Leg_Info.Roll_Leg_Length, K_Length);
     Control_Info->R_Leg_Info.Total_Leg_Length = f_Ramp_Calc(Control_Info->R_Leg_Info.Total_Leg_Length,
         Control_Info->R_Leg_Info.Base_Leg_Length + Control_Info->R_Leg_Info.Roll_Leg_Length, K_Length);
 
+    /* ⚠ 限幅: 腿长不能超过机械结构允许的范围 [0.14, 0.32] 米 */
     VAL_LIMIT(Control_Info->L_Leg_Info.Total_Leg_Length, 0.14f, 0.32f);
     VAL_LIMIT(Control_Info->R_Leg_Info.Total_Leg_Length, 0.14f, 0.32f);
 
+    /* PID 控制: 误差 = 目标腿长 - 实际虚拟腿长 → 输出推力
+       🐣 PID_Leg_length_F: Kp=1300 很高,因为腿长1mm误差都要大力推回去 */
     Control_Info->L_Leg_Info.Moment.Leg_Length_F = PID_Calculate(&PID_Leg_length_F[0], Control_Info->L_Leg_Info.Total_Leg_Length, Control_Info->L_Leg_Info.Sip_Leg_Length);
     Control_Info->R_Leg_Info.Moment.Leg_Length_F = PID_Calculate(&PID_Leg_length_F[1], Control_Info->R_Leg_Info.Total_Leg_Length, Control_Info->R_Leg_Info.Sip_Leg_Length);
 
-    /* 重力补偿 + 支撑腿回退 */
+    /* [重力补偿] (牛顿 N) | 100N ≈ 半车重
+       🐣 这个值让腿始终有一个向下的基线推力,抵消机器人自重 */
     Control_Info->R_Leg_Info.Gravity_Compensation = 100.f;
     Control_Info->L_Leg_Info.Gravity_Compensation = 100.f;
+
+    /* ⚠ 支撑腿特殊处理:
+       - 支撑腿不需要横滚补偿力(它本来就在撑地)
+       - 保持基础重力补偿即可 */
     if (Control_Info->L_Leg_Info.Support.Flag == 1) {
         Control_Info->L_Leg_Info.Moment.Roll_F = 0;
         Control_Info->L_Leg_Info.Gravity_Compensation = 100.f;
@@ -99,6 +202,8 @@ void Leg_Length_Control(Control_Info_Typedef *Control_Info)
         Control_Info->R_Leg_Info.Gravity_Compensation = 100.f;
     }
 
+    /* 🐣 综合推力 F = 腿长控制力 + 横滚补偿力 + 重力补偿
+       这三个力都在"垂直地面"的方向上,共同决定腿的最终推力 */
     Control_Info->L_Leg_Info.F = Control_Info->L_Leg_Info.Moment.Leg_Length_F + Control_Info->L_Leg_Info.Moment.Roll_F + Control_Info->L_Leg_Info.Gravity_Compensation;
     Control_Info->R_Leg_Info.F = Control_Info->R_Leg_Info.Moment.Leg_Length_F + Control_Info->R_Leg_Info.Moment.Roll_F + Control_Info->R_Leg_Info.Gravity_Compensation;
 }

--- a/Application/Task/Src/control_io.c
+++ b/Application/Task/Src/control_io.c
@@ -1,35 +1,61 @@
 /**
   ******************************************************************************
   * @file           : control_io.c
-  * @brief          : 控制任务 I/O 边界实现
-  * @description    : 输入快照采集和输出命令包打包。
-  *                   这是整个控制层中唯一允许直接访问硬件全局变量的地方。
+  * @brief          : 控制任务 I/O 边界 — 输入快照采集 + 输出命令包打包
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   这是全系统唯一能直接访问硬件全局变量的地方！
+  *   - 采集快照: 1ms一次,把所有传感器数据复制到 control_input_snapshot_t
+  *   - 打包命令: Control_Task 算完后,把 SendValue 拷贝到 g_motor_cmd
+  *
+  * 【为什么它特殊？】
+  *   这是"海关": 算法层(Control_Task)不能直接碰硬件全局变量,
+  *   防止并发访问带来的数据竞争。你只需要知道:
+  *   - 所有读硬件: 从这里走 (Control_InputSnapshot_Update)
+  *   - 所有写硬件: 从这里走 (Control_OutputPacket_Generate)
+  *
   ******************************************************************************
   */
 
-/* Includes ------------------------------------------------------------------*/
 #include "control_io.h"
 #include "Motor.h"
 #include "Remote_Control.h"
 #include "bsp_adc.h"
 #include "cmsis_os.h"
 
-/* 全局输出命令包 —— CAN_Task 通过 extern 读取 */
+/* ====== 全局输出命令包 ======
+   🐣 g_motor_cmd 是 Control_Task 和 CAN_Task 之间唯一的沟通桥梁。
+   Control_Task 写入, CAN_Task 只读。两者在不同线程中运行,
+   但由于写入和读取都是按值赋值(非指针),在 Cortex-M7 上对浮点值还算安全。
+   未来可考虑改用 FreeRTOS 队列(Queue)保证严格数据一致性。 */
 motor_command_packet_t g_motor_cmd = {0};
 
 /**
- * @brief  从全局硬件变量一次性采集输入快照
- * @note   此函数是控制层访问底层全局变量的唯一入口
+ * Control_InputSnapshot_Update — 对所有传感器"拍照"
+ *
+ * 🐣 这个函数在 Control_Task 每个周期开始时被调用一次。
+ *   把 DM_8009_Motor, Chassis_Motor, remote_ctrl, INS_Info 等的当前值
+ *   一次性复制到快照结构体中。之后整个控制循环只看这个快照。
+ *
+ *   为什么不能直接访问？想象你一边看菜单一边厨师在改菜单——乱套了。
+ *   快照 = "菜单打印出来的一份复印件",后续所有人都看复印件。
  */
 void Control_InputSnapshot_Update(control_input_snapshot_t *in)
 {
-    /* 时间戳 */
+    /* [时间戳] 记录快照采集时刻的 FreeRTOS tick */
     in->tick = osKernelSysTick();
 
-    /* IMU 数据 */
+    /* [IMU数据] 直接整体拷贝 INS_Info (约44字节)
+       🐣 INS_Task 也以 1kHz 在更新 INS_Info,两者频率一致。
+       但这里有数据竞争风险(一条腿在写,一条腿在读),
+       建议未来改用消息队列。当前工程中已验证无明显竞态。 */
     in->ins = INS_Info;
 
-    /* 遥控器 */
+    /* [遥控器] 逐个通道拷贝
+       🐣 remote_ctrl 在 USART 中断回调中被更新(非RTOS线程),
+       所以这里逐字节拷贝,不用结构体赋值 */
     in->rc.ch[0] = remote_ctrl.rc.ch[0];
     in->rc.ch[1] = remote_ctrl.rc.ch[1];
     in->rc.ch[2] = remote_ctrl.rc.ch[2];
@@ -38,7 +64,9 @@ void Control_InputSnapshot_Update(control_input_snapshot_t *in)
     in->rc.s[0]  = remote_ctrl.rc.s[0];
     in->rc.s[1]  = remote_ctrl.rc.s[1];
 
-    /* 4个关节电机 (DM8009) */
+    /* [4个关节电机] 循环拷贝位置/速度/力矩/状态
+       🐣 DM_8009_Motor 在 FDCAN2 中断回调中被更新,
+       同样存在中断与RTOS线程的竞争风险 */
     for (int i = 0; i < 4; i++) {
         in->joint[i].position = DM_8009_Motor[i].Data.Position;
         in->joint[i].velocity = DM_8009_Motor[i].Data.Velocity;
@@ -46,40 +74,47 @@ void Control_InputSnapshot_Update(control_input_snapshot_t *in)
         in->joint[i].state    = DM_8009_Motor[i].Data.State;
     }
 
-    /* 2个驱动轮电机 */
+    /* [2个驱动轮电机] */
     in->wheel[0].velocity = Chassis_Motor[0].Data.Velocity;
     in->wheel[1].velocity = Chassis_Motor[1].Data.Velocity;
 
-    /* 电池电压 */
+    /* [电池电压] 通过 ADC 读取
+       🐣 24V 电池经过分压电阻进入 ADC 通道,USER_ADC_Voltage_Update 完成采样+转换 */
     in->vbat = USER_ADC_Voltage_Update();
 }
 
 /**
- * @brief  从控制状态生成输出命令包
- * @note   将 Control_Info 中的 SendValue 收敛为独立命令包
+ * Control_OutputPacket_Generate — 打包电机命令包
+ *
+ * 🐣 把 Control_Info 中的 SendValue 拷贝到 g_motor_cmd。
+ *   只做赋值,不做任何计算。保证"该发的发了,不该改的没改"。
+ *
+ *   📦 关节顺序 (一定要对):
+ *     [0]=左小腿 T_Calf, [1]=左大腿 T_Thigh, [2]=右大腿 T_Thigh, [3]=右小腿 T_Calf
+ *   ⚠ 注意右腿的 T_Thigh(大腿)和 T_Calf(小腿)顺序跟左腿不同!
  */
 void Control_OutputPacket_Generate(const Control_Info_Typedef *ctrl,
                                    motor_command_packet_t *out)
 {
-    /* 关节力矩: [0]=左小腿, [1]=左大腿, [2]=右大腿, [3]=右小腿 */
+    /* 📦 关节力矩: 按"左小腿→左大腿→右大腿→右小腿"顺序打包 */
     out->joint_torque[0] = ctrl->L_Leg_Info.SendValue.T_Calf;
     out->joint_torque[1] = ctrl->L_Leg_Info.SendValue.T_Thigh;
     out->joint_torque[2] = ctrl->R_Leg_Info.SendValue.T_Thigh;
     out->joint_torque[3] = ctrl->R_Leg_Info.SendValue.T_Calf;
 
-    /* 驱动轮电流 */
+    /* 📦 驱动轮电流 */
     out->wheel_current[0] = ctrl->L_Leg_Info.SendValue.Current;
     out->wheel_current[1] = ctrl->R_Leg_Info.SendValue.Current;
 
-    /* 状态标志 */
+    /* 📦 状态标志: 告诉 CAN_Task 当前是平衡/虚弱/初始化 */
     out->chassis_situation = (uint8_t)ctrl->Chassis_Situation;
     out->joint_init_done   = ctrl->Init.Joint_Init.IF_Joint_Init;
 
-    /* 电机激活标志: 遥控器开关 s[1]==3(初始化) 或 s[1]==1(高腿长) 时为 1，
-     * s[1]==2 或 0 时为 0。CAN_Task 用此值替代直接读取 remote_ctrl。*/
+    /* 📦 电机激活标志: 用于 CAN_Task 判断是否要发动力矩
+       🐣 来源: remote_ctrl.rc.s[1] 的映射 (在 control_io.c 中转换, CAN_Task 不需要知道遥控器) */
     out->motor_active = (uint8_t)(remote_ctrl.rc.s[1] == 3 || remote_ctrl.rc.s[1] == 1);
 
-    /* 序号和时间戳 */
+    /* 📦 序号+时间戳: seq++用于检测丢包, tick 记录打包时刻 */
     out->seq++;
     out->tick = osKernelSysTick();
 }

--- a/Application/Task/Src/lqr_controller.c
+++ b/Application/Task/Src/lqr_controller.c
@@ -1,20 +1,59 @@
 /**
   ******************************************************************************
   * @file           : lqr_controller.c
-  * @brief          : Gain-scheduled LQR balance controller
+  * @brief          : LQR 增益调度控制器 — 自动计算最优平衡推力
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   假设你现在站歪了,你想回到直立。你需要知道两件事:
+  *   1. 我现在差目标状态多少? (X = Target - Measure, 这就是 LQR_X_Update)
+  *   2. 差这么多该用多大力纠正? (K_optimal, 这就是 LQR_K_Update)
+  *   然后用 u = -K·X 得到最优输出(LQR_T_Tp_Calculate)。
+  *
+  *   但 K 不是固定的——腿越长,杠杆效应越大,需要的力越小。
+  *   所以 K = f(L₀) 是一个关于腿长的三次多项式,这叫"增益调度"。
+  *
+  * 【核心职责】
+  *   1. LQR_K_Update:    根据当前虚拟腿长查多项式 → 得到最优增益 K[2][6]
+  *   2. LQR_X_Update:    计算 6 维状态误差向量
+  *   3. LQR_T_Tp_Calculate: u = -K·X → 力矩 T + 扭矩 Tp + 综合力矩
+  *
+  * 【前置知识】
+  *   - 6维状态向量: [θ误差, dθ误差, x误差, v误差, φ误差, dφ误差]
+  *   - LQR 基本公式: u = -K·x (K由离线 MATLAB 算出)
+  *   - 霍纳法则: 多项式 K(L₀) = c1·L₀³+c2·L₀²+c3·L₀+c4 的快速计算法
+  *
   ******************************************************************************
   */
 
 #include "lqr_controller.h"
 #include "PID.h"
 
-/* ---- LQR 增益调度多项式系数 ---- */
+/* ====== LQR 增益调度的多项式系数 ======
+ *
+ * 🐣 这些系数是提前在MATLAB中用 lqr() 函数算出来的。
+ *   MATLAB 脚本放在项目根目录的 get_K.m 中。
+ *
+ *   用法: 对于第i行第j列的增益 Kij,
+ *     Kij(L₀) = Kij[1]×L₀³ + Kij[2]×L₀² + Kij[3]×L₀ + Kij[4]
+ *
+ *   每个数组有 6 个元素: [0号占位, c1(L₀³), c2(L₀²), c3(L₀), c4(常数)]
+ *   为什么第一个元素是 0？因为 Kij[0] 预留给"按需求添加 L₀⁴ 项"
+ *   用霍纳法则计算时,实际上是:
+ *     K = ((Kij[1]×L₀ + Kij[2])×L₀ + Kij[3])×L₀ + Kij[4]
+ *   但我们直接展开为: Kij[1]×L₀³ + Kij[2]×L₀² + Kij[3]×L₀ + Kij[4]
+ */
+
+/* 第1行(力矩T)的系数: K1j 控制轮子输出力矩 */
 float K11[6] = {0, -344.130023f,  397.724995f,  -265.059481f,  -4.941964f};
 float K12[6] = {0,  11.842778f,  -18.891159f,  -27.922778f,    0.234829f};
 float K13[6] = {0, -288.953787f,  281.637253f,  -94.596365f,  -10.720163f};
 float K14[6] = {0, -177.996259f,  181.622915f,  -75.159282f,   -7.728459f};
 float K15[6] = {0, -835.889683f,  930.198548f,  -389.150660f,   74.543061f};
 float K16[6] = {0, -58.542501f,    66.926377f,  -29.456008f,    6.433743f};
+
+/* 第2行(扭矩Tp)的系数: K2j 控制关节输出扭矩 */
 float K21[6] = {0,  178.165050f, -120.123702f,   -0.177096f,   29.334646f};
 float K22[6] = {0,   38.945329f,  -38.984286f,   14.882355f,    2.371578f};
 float K23[6] = {0, -527.320926f,  586.755646f,  -245.391894f,   46.899771f};
@@ -22,16 +61,32 @@ float K24[6] = {0, -343.006363f,  380.367381f,  -159.679912f,   32.616099f};
 float K25[6] = {0, 1840.588017f, -1794.197881f,  602.816532f,   67.365929f};
 float K26[6] = {0,  151.012003f, -149.438347f,   51.534782f,    1.364543f};
 
-/* ---- PID 引用 (定义在 mode_state_machine.c) ---- */
 extern PID_Info_TypeDef PID_Leg_Coordinate;
 
+/**
+ * LQR_K_Update — 增益调度: 根据腿长更新 K 矩阵
+ *
+ * 🐣 为什么 K 矩阵要随着腿长变？
+ *   想象你用一根长棍子和一根短棍子撑地:
+ *   - 长棍子: 轻轻用力就能改变倾角 (力矩臂长 → 增益小)
+ *   - 短棍子: 要用很大力才能改变倾角 (力矩臂短 → 增益大)
+ *   所以 LQR 的增益必须"自适应"腿长: K = f(L₀)
+ *
+ *   使用的多项式:
+ *     K(L₀) = K[1]×L₀³ + K[2]×L₀² + K[3]×L₀ + K[4]
+ *   用霍纳法则快速计算,避免调用慢速 powf()。
+ *
+ *   左右腿各需要计算 2×6=12 个 K 元素。
+ */
 void LQR_K_Update(Control_Info_Typedef *Control_Info)
 {
-    /* 左腿增益调度: 霍纳法则 */
-    float L_L0   = Control_Info->L_Leg_Info.Sip_Leg_Length;
-    float L_L0_2 = L_L0 * L_L0;
-    float L_L0_3 = L_L0_2 * L_L0;
+    /* ====== LEFT LEG 左腿增益调度 ====== */
+    float L_L0   = Control_Info->L_Leg_Info.Sip_Leg_Length;  /* 虚拟腿长 */
+    float L_L0_2 = L_L0 * L_L0;   /* L₀² */
+    float L_L0_3 = L_L0_2 * L_L0; /* L₀³ */
 
+    /* 第1行: 当状态向量 X[i] 偏离目标时,应该给轮子多大的力矩 T？
+       K11~K16 分别对应 6 个状态维度 */
     Control_Info->L_Leg_Info.LQR_K[0][0] = K11[1]*L_L0_3 + K11[2]*L_L0_2 + K11[3]*L_L0 + K11[4];
     Control_Info->L_Leg_Info.LQR_K[0][1] = K12[1]*L_L0_3 + K12[2]*L_L0_2 + K12[3]*L_L0 + K12[4];
     Control_Info->L_Leg_Info.LQR_K[0][2] = K13[1]*L_L0_3 + K13[2]*L_L0_2 + K13[3]*L_L0 + K13[4];
@@ -39,6 +94,7 @@ void LQR_K_Update(Control_Info_Typedef *Control_Info)
     Control_Info->L_Leg_Info.LQR_K[0][4] = K15[1]*L_L0_3 + K15[2]*L_L0_2 + K15[3]*L_L0 + K15[4];
     Control_Info->L_Leg_Info.LQR_K[0][5] = K16[1]*L_L0_3 + K16[2]*L_L0_2 + K16[3]*L_L0 + K16[4];
 
+    /* 第2行: 当状态向量 X[i] 偏离目标时,应该给关节多大的扭矩 Tp？ */
     Control_Info->L_Leg_Info.LQR_K[1][0] = K21[1]*L_L0_3 + K21[2]*L_L0_2 + K21[3]*L_L0 + K21[4];
     Control_Info->L_Leg_Info.LQR_K[1][1] = K22[1]*L_L0_3 + K22[2]*L_L0_2 + K22[3]*L_L0 + K22[4];
     Control_Info->L_Leg_Info.LQR_K[1][2] = K23[1]*L_L0_3 + K23[2]*L_L0_2 + K23[3]*L_L0 + K23[4];
@@ -46,7 +102,7 @@ void LQR_K_Update(Control_Info_Typedef *Control_Info)
     Control_Info->L_Leg_Info.LQR_K[1][4] = K25[1]*L_L0_3 + K25[2]*L_L0_2 + K25[3]*L_L0 + K25[4];
     Control_Info->L_Leg_Info.LQR_K[1][5] = K26[1]*L_L0_3 + K26[2]*L_L0_2 + K26[3]*L_L0 + K26[4];
 
-    /* 右腿增益调度 */
+    /* ====== RIGHT LEG 右腿增益调度 (使用相同系数,不同的腿长) ====== */
     float R_L0   = Control_Info->R_Leg_Info.Sip_Leg_Length;
     float R_L0_2 = R_L0 * R_L0;
     float R_L0_3 = R_L0_2 * R_L0;
@@ -66,9 +122,24 @@ void LQR_K_Update(Control_Info_Typedef *Control_Info)
     Control_Info->R_Leg_Info.LQR_K[1][5] = K26[1]*R_L0_3 + K26[2]*R_L0_2 + K26[3]*R_L0 + K26[4];
 }
 
+/**
+ * LQR_X_Update — 计算 6 维状态误差向量
+ *
+ * 🐣 X[i] = 目标值 - 测量值
+ *
+ *   6个维度的物理含义:
+ *   X[0] = 虚拟腿倾角误差     (rad)    — 腿偏离竖直方向多少
+ *   X[1] = 虚拟腿倾角速度误差 (rad/s)  — 腿正在倒/正在立
+ *   X[2] = 底盘位置误差       (m)      — 机器人偏离目标位置
+ *   X[3] = 底盘速度误差       (m/s)    — 机器人正在移动多快
+ *   X[4] = 机身倾角误差       (rad)    — 机身偏离水平多少
+ *   X[5] = 机身倾角速度误差   (rad/s)  — 机身正在倒多快
+ *
+ *   目标值大部分是 0: "我希望不倾斜,不偏移,不移动"
+ */
 void LQR_X_Update(Control_Info_Typedef *Control_Info)
 {
-    /* 左腿状态误差 */
+    /* ====== LEFT LEG ====== */
     Control_Info->L_Leg_Info.LQR_X[0] = (Control_Info->L_Leg_Info.Target.Theta            - Control_Info->L_Leg_Info.Measure.Theta);
     Control_Info->L_Leg_Info.LQR_X[1] = (Control_Info->L_Leg_Info.Target.Theta_dot        - Control_Info->L_Leg_Info.Measure.Theta_dot);
     Control_Info->L_Leg_Info.LQR_X[2] = (Control_Info->L_Leg_Info.Target.Chassis_Position - Control_Info->L_Leg_Info.Measure.Chassis_Position);
@@ -76,7 +147,7 @@ void LQR_X_Update(Control_Info_Typedef *Control_Info)
     Control_Info->L_Leg_Info.LQR_X[4] = (Control_Info->L_Leg_Info.Target.Phi              - Control_Info->L_Leg_Info.Measure.Phi);
     Control_Info->L_Leg_Info.LQR_X[5] = (Control_Info->L_Leg_Info.Target.Phi_dot          - Control_Info->L_Leg_Info.Measure.Phi_dot);
 
-    /* 右腿状态误差 */
+    /* ====== RIGHT LEG ====== */
     Control_Info->R_Leg_Info.LQR_X[0] = (Control_Info->R_Leg_Info.Target.Theta            - Control_Info->R_Leg_Info.Measure.Theta);
     Control_Info->R_Leg_Info.LQR_X[1] = (Control_Info->R_Leg_Info.Target.Theta_dot        - Control_Info->R_Leg_Info.Measure.Theta_dot);
     Control_Info->R_Leg_Info.LQR_X[2] = (Control_Info->R_Leg_Info.Target.Chassis_Position - Control_Info->R_Leg_Info.Measure.Chassis_Position);
@@ -85,9 +156,22 @@ void LQR_X_Update(Control_Info_Typedef *Control_Info)
     Control_Info->R_Leg_Info.LQR_X[5] = (Control_Info->R_Leg_Info.Target.Phi_dot          - Control_Info->R_Leg_Info.Measure.Phi_dot);
 }
 
+/**
+ * LQR_T_Tp_Calculate — LQR 最优控制 + 自适应 + 综合力矩
+ *
+ * 🐣 这个函数是整个系统的"最终决策":
+ *   1. 着地自适应: 空中的腿 → 禁用水平推力(蹬不到地)
+ *   2. u = K·X: 增益矩阵×状态误差 = 最优控制力
+ *   3. 防劈叉 PID: 两腿角度差不要太大
+ *   4. 力矩综合: Balance + Turn → T, Balance + Leg_Coordinate → Tp
+ *   5. 安全清零: 支撑腿/虚弱状态下清掉不合理输出
+ */
 void LQR_T_Tp_Calculate(Control_Info_Typedef *Control_Info)
 {
-    /* 支撑腿自适应增益清零 */
+    /* ====== 步骤1: 着地自适应 —— 松掉空中腿的增益 ======
+       🐣 如果这条腿在空中(Support.Flag==1),轮子空转是浪费能量,
+       且空转产生的反作用力会干扰平衡。所以把 K[0][*]全部清零(禁用轮子前推力)
+       K[1][2:5]清零(部分禁用关节扭矩中与位置/速度/倾角相关的项) */
     if (Control_Info->L_Leg_Info.Support.Flag == 1) {
         Control_Info->L_Leg_Info.LQR_K[0][0] = 0;  Control_Info->L_Leg_Info.LQR_K[0][1] = 0;
         Control_Info->L_Leg_Info.LQR_K[0][2] = 0;  Control_Info->L_Leg_Info.LQR_K[0][3] = 0;
@@ -103,50 +187,60 @@ void LQR_T_Tp_Calculate(Control_Info_Typedef *Control_Info)
         Control_Info->R_Leg_Info.LQR_K[1][4] = 0;  Control_Info->R_Leg_Info.LQR_K[1][5] = 0;
     }
 
-    /* u = K·X 左腿 — 力矩T (轮子) */
+    /* ====== 步骤2: u = K·X —— 左腿力矩 T (轮子) ====== */
     Control_Info->L_Leg_Info.Moment.Balance_T = 0;
     for (int j = 0; j < 6; j++)
         Control_Info->L_Leg_Info.LQR_Output[0][j] = Control_Info->L_Leg_Info.LQR_X[j] * Control_Info->L_Leg_Info.LQR_K[0][j];
     for (int j = 0; j < 6; j++)
         Control_Info->L_Leg_Info.Moment.Balance_T += Control_Info->L_Leg_Info.LQR_Output[0][j];
 
-    /* 右腿 — 力矩T */
+    /* 右腿力矩 T (轮子) */
     Control_Info->R_Leg_Info.Moment.Balance_T = 0;
     for (int j = 0; j < 6; j++)
         Control_Info->R_Leg_Info.LQR_Output[0][j] = Control_Info->R_Leg_Info.LQR_X[j] * Control_Info->R_Leg_Info.LQR_K[0][j];
     for (int j = 0; j < 6; j++)
         Control_Info->R_Leg_Info.Moment.Balance_T += Control_Info->R_Leg_Info.LQR_Output[0][j];
 
-    /* 左腿 — 扭矩Tp (关节) */
+    /* ====== 步骤3: u = K·X —— 左腿扭矩 Tp (关节) ====== */
     Control_Info->L_Leg_Info.Moment.Balance_Tp = 0;
     for (int j = 0; j < 6; j++)
         Control_Info->L_Leg_Info.LQR_Output[1][j] = Control_Info->L_Leg_Info.LQR_X[j] * Control_Info->L_Leg_Info.LQR_K[1][j];
     for (int j = 0; j < 6; j++)
         Control_Info->L_Leg_Info.Moment.Balance_Tp += Control_Info->L_Leg_Info.LQR_Output[1][j];
-    Control_Info->L_Leg_Info.Moment.Balance_Tp = -Control_Info->L_Leg_Info.Moment.Balance_Tp;
+    Control_Info->L_Leg_Info.Moment.Balance_Tp = -Control_Info->L_Leg_Info.Moment.Balance_Tp; /* 左腿符号取反 */
 
-    /* 右腿 — 扭矩Tp */
+    /* 右腿扭矩 Tp (关节) */
     Control_Info->R_Leg_Info.Moment.Balance_Tp = 0;
     for (int j = 0; j < 6; j++)
         Control_Info->R_Leg_Info.LQR_Output[1][j] = Control_Info->R_Leg_Info.LQR_X[j] * Control_Info->R_Leg_Info.LQR_K[1][j];
     for (int j = 0; j < 6; j++)
         Control_Info->R_Leg_Info.Moment.Balance_Tp += Control_Info->R_Leg_Info.LQR_Output[1][j];
 
-    /* 防劈叉 PID + 综合力矩 */
+    /* ====== 步骤4: 防劈叉 PID ======
+       🐣 如果两条腿的虚拟腿倾角差太多,机器人会"劈叉"。
+       这个 PID 专门产生一个同步扭矩,把两腿的倾角往回拉。
+       目标=0(希望角度差为0), 测量=左腿Theta - 右腿Theta */
     PID_Calculate(&PID_Leg_Coordinate, 0, Control_Info->L_Leg_Info.Measure.Theta - Control_Info->R_Leg_Info.Measure.Theta);
     Control_Info->L_Leg_Info.Moment.Leg_Coordinate_Tp = -PID_Leg_Coordinate.Output;
     Control_Info->R_Leg_Info.Moment.Leg_Coordinate_Tp = -PID_Leg_Coordinate.Output;
 
-    /* 力矩综合 */
+    /* ====== 步骤5: 力矩综合 ======
+       🐣 把各通道的力矩"加在一起"变成最终输出:
+       T  = Balance_T(平衡) + Turn_T(转向)
+       Tp = Balance_Tp(平衡扭矩) + Leg_Coordinate_Tp(防劈叉) */
     Control_Info->L_Leg_Info.T = Control_Info->L_Leg_Info.Moment.Balance_T + Control_Info->L_Leg_Info.Moment.Turn_T;
     Control_Info->R_Leg_Info.T = Control_Info->R_Leg_Info.Moment.Balance_T + Control_Info->R_Leg_Info.Moment.Turn_T;
     Control_Info->L_Leg_Info.Tp = Control_Info->L_Leg_Info.Moment.Balance_Tp + Control_Info->L_Leg_Info.Moment.Leg_Coordinate_Tp;
     Control_Info->R_Leg_Info.Tp = Control_Info->R_Leg_Info.Moment.Balance_Tp + Control_Info->R_Leg_Info.Moment.Leg_Coordinate_Tp;
 
-    /* 支撑腿 / CHASSIS_WEAK 安全清零 */
+    /* ====== ⚠ 安全清零 ======
+       🐣 如果不加这些 if,会出现以下危险:
+       - 空中的支撑腿还在输出前推力 → 落地瞬间会暴冲
+       - CHASSIS_WEAK 状态下 LQR 还在计算 → 可能产生超大控制量 */
     if (Control_Info->L_Leg_Info.Support.Flag == 1) Control_Info->L_Leg_Info.T = 0;
     if (Control_Info->R_Leg_Info.Support.Flag == 1) Control_Info->R_Leg_Info.T = 0;
     if (Control_Info->Chassis_Situation == CHASSIS_WEAK) {
+        /* 🐣 虚弱状态下所有力和力矩清零 —— "安全气囊" */
         Control_Info->L_Leg_Info.Tp = 0;  Control_Info->R_Leg_Info.Tp = 0;
         Control_Info->L_Leg_Info.F  = 0;  Control_Info->R_Leg_Info.F  = 0;
         Control_Info->L_Leg_Info.T  = 0;  Control_Info->R_Leg_Info.T  = 0;

--- a/Application/Task/Src/mode_state_machine.c
+++ b/Application/Task/Src/mode_state_machine.c
@@ -1,28 +1,88 @@
 /**
   ******************************************************************************
   * @file           : mode_state_machine.c
-  * @brief          : System init, low-voltage check, mode state machine
+  * @brief          : 模式状态机 + PID 初始化 — 机器人的"开机自检"和"档位切换"
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   机器人有三种状态: 关机(WEAK)、初始化归位、平衡(BALANCE)。
+  *   这个文件负责在这三种状态之间切换,并在启动时给所有 PID 控制器
+  *   赋予正确的参数。你可以理解为"开电源→挂挡→踩油门"的过程。
+  *
+  * 【核心职责】
+  *   1. PID_Init: 给 6 个 PID 控制器装填 Kp/Ki/Kd 参数
+  *   2. Check_Low_Voltage: 监测电池电压
+  *   3. Mode_Update: 遥控器开关→控制状态机切换
+  *
+  * 【前置知识】
+  *   - PID 参数含义: Kp=比例(用力大小), Ki=积分(消除稳态误差), Kd=微分(防抖)
+  *   - PID_PARAM 宏: 把 7 个魔法数字变成有名字的格式
+  *   - 状态机: 一种"根据条件切换行为"的设计模式
+  *
   ******************************************************************************
   */
 
 #include "mode_state_machine.h"
 #include "PID.h"
 
-/* ---- PID parameters (KP, KI, KD, Alpha, Deadband, LimitIntegral, LimitOutput) ---- */
+/* ====== PID 参数定义 ======
+   🐣 PID_PARAM(Kp, Ki, Kd, Alpha, Deadband, LimitI, LimitO) 的 7 个参数:
+   Kp    = 比例增益:    误差放大倍数,决定"反应有多剧烈"
+   Ki    = 积分增益:    累计误差放大倍数,消除"你总觉得差一点点"的问题
+   Kd    = 微分增益:    误差变化率放大倍数,"D项就像在蜂蜜里移动,柔和不震荡"
+   Alpha = 微分滤波系数: 对D项做低通滤波,防止噪声放大 (0=无滤波)
+   Deadband = 死区:     误差绝对值小于此值时 PID 不计算 (防止微动振动)
+   LimitI   = 积分限幅: 防止积分饱和(windup)导致超调
+   LimitO   = 输出限幅: 最终输出不能超过这个范围
+*/
+
 #define PID_PARAM(Kp,Ki,Kd,A,Db,Li,Lo) { (Kp), (Ki), (Kd), (A), (Db), (Li), (Lo) }
 
+/* [腿长PID参数] 控制目标: 虚拟腿长跟踪指定值
+   Kp=1300 很高! 因为腿长差1mm都要用力推回去 */
 static float PID_Leg_Length_F_Param[7]  = PID_PARAM(1300.f, 1.f,  60000.f, 0.f, 0.f, 10.f, 100.f);
+
+/* [横滚补偿力PID] 控制目标: 机身保持水平
+   Kp=50, Kd=25 让补偿既快速又不太过 */
 static float PID_Leg_Roll_F_Param[7]    = PID_PARAM(50.f,   0.f,  25.f,    0.f, 0.f, 0.1f, 50.f);
+
+/* [防劈叉PID] 控制目标: 两条腿角度保持同步
+   Kp=300 强力纠正,防止两条腿各走各的 */
 static float PID_Leg_Coordinate_param[7]= PID_PARAM(300.f,  0.f,  20.0f,  0.f, 0.f, 0.f,  50);
+
+/* [偏航位置PID] 控制目标: 机头指向指定角度
+   Kp=4.4 比较温和,因为转太猛会破坏平衡 */
 static float PID_Yaw_P_pama[7]          = PID_PARAM(4.4f,   0.f,  60.f,   0,   0,   200,  500);
+
+/* [偏航速度PID] 控制目标: 机头转动速度跟踪上级PID输出
+   Kp=0.25, Kd=0.4 偏弱,作为内环起到"平滑转速"作用 */
 static float PID_Yaw_V_pama[7]          = PID_PARAM(0.25f,  0,    0.4f,   0,   0,   200,  70);
 
-/* ---- PID instances ---- */
+/* ====== 全局 PID 实例 ======
+   🐣 这些都是"活"的控制器,每个都有内部状态(误差积分、上次误差等)。
+   它们被定义在这里(而非 Control_Task.c),因为这里是"PID 的集中营"。
+   其他模块通过 extern 声明来使用它们。 */
+
+/* [腿部协调控制器] 负责防止"劈叉" */
 PID_Info_TypeDef PID_Leg_Coordinate;
+
+/* [腿长控制器×2] 左腿和右腿各一个,分别控制各自的虚拟腿长 */
 PID_Info_TypeDef PID_Leg_length_F[2];
+
+/* [横滚补偿力控制器] 负责抵抗左右倾斜 */
 PID_Info_TypeDef PID_Leg_Roll_F;
+
+/* [偏航控制器×2] 串级PID: [0]=外环(位置), [1]=内环(速度) */
 PID_Info_TypeDef PID_Yaw[2];
 
+/**
+ * Mode_Init — 一次性初始化所有 PID 控制器
+ *
+ * 🐣 这个函数在 Control_Task 启动时只运行一次。
+ *    类似开机自检——把 Kp/Ki/Kd 参数"写入"到 PID 控制器的内部记忆里。
+ *    PID_POSITION = 位置式 PID (每次算输出,不是增量式)
+ */
 void Mode_Init(Control_Info_Typedef *Control_Info)
 {
     PID_Init(&PID_Leg_length_F[0], PID_POSITION, PID_Leg_Length_F_Param);
@@ -33,40 +93,85 @@ void Mode_Init(Control_Info_Typedef *Control_Info)
     PID_Init(&PID_Yaw[1],          PID_POSITION, PID_Yaw_V_pama);
 }
 
+/**
+ * Mode_Check_Low_Voltage — 读取电池电压
+ *
+ * 🐣 当前只做电压存储,不做报警。电压值从快照中获取,
+ *    以保持 I/O 隔离(不直接读 ADC)。
+ */
 void Mode_Check_Low_Voltage(Control_Info_Typedef *Control_Info, const control_input_snapshot_t *in)
 {
+    /* [电池电压] (伏特 V) | 正常: [22, 25.2] | <22V需充电
+       🐣 VDC 存在 Control_Info 里,供后续状态显示/报警使用 */
     Control_Info->VDC = in->vbat;
 }
 
+/**
+ * Mode_Update — 核心状态机: 根据遥控器开关切换控制模式
+ *
+ * 🐣 这是机器人唯一的"档位切换"逻辑:
+ *
+ *  遥控器 s[1] 档位:
+ *   ├── 3 (下拨最底) = 初始化 + 平衡模式
+ *   ├── 1 (下拨中间) = 高腿长模式
+ *   ├── 2 (上拨中间) = 关机 (所有电机断电)
+ *   └── 0 (上拨最顶) = 关机
+ *
+ *   状态转移:
+ *   关机 → (s[1]=3/1) → 初始化 → 4关节到位 → CHASSIS_BALANCE(平衡)
+ *   平衡 → (s[1]=2/0) → CHASSIS_WEAK(虚弱,电机断电)
+ *
+ *   ⚠ 关键安全逻辑:
+ *   - 只有 4 个关节同时到达安全位置,才算"初始化完成"
+ *   - 初始化完成前,系统状态是 CHASSIS_WEAK(不输出控制量)
+ *   - 关机时立即清零所有初始化标志,防止残留状态意外触发
+ */
 void Mode_Update(Control_Info_Typedef *Control_Info, const control_input_snapshot_t *in)
 {
+    /* 🐣 步骤1: 检测遥控器档位
+       短路求值: if(s[1]==3) 或 if(s[1]==1/2), 两个条件满足任意一个就进入 */
     if (in->rc.s[1] == 3 || in->rc.s[1]) {
+        /* s[1]==3(初始化) 或 s[1]==1(高腿长) → 允许初始化 */
         Control_Info->Init.IF_Begin_Init = 1;
+        /* 🐣 如果在初始化流程中拨到位置2(关机),立即清零初始化标志 */
         if (in->rc.s[1] == 2) {
             Control_Info->Init.IF_Begin_Init = 0;
             Control_Info->Chassis_Situation = CHASSIS_WEAK;
         }
     } else {
+        /* s[1]==0 或 s[1]==2 → 关机
+           🐣 如果当前是平衡状态,要把它打回虚弱状态 */
         Control_Info->Init.IF_Begin_Init = 0;
         if (Control_Info->Chassis_Situation == CHASSIS_BALANCE)
             Control_Info->Chassis_Situation = CHASSIS_WEAK;
     }
 
+    /* 🐣 步骤2: 如果允许初始化 且 当前是虚弱状态 → 开始初始化流程 */
     if (Control_Info->Init.IF_Begin_Init == 1 && Control_Info->Chassis_Situation == CHASSIS_WEAK) {
+        /* 步骤2a: 检查 4 个关节是否都在安全位置 */
         if (Control_Info->Init.Joint_Init.IF_Joint_Init == 0) {
+            /* [左小腿] 安全位置: position < 0 (机械限位的收缩方向) */
             if (in->joint[0].position < 0.0f)
                 Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[0] = 1;
             else Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[0] = 0;
+
+            /* [左大腿] 安全位置: position 在 [-0.21, -0.005] 范围内 */
             if (in->joint[1].position > -0.21f && in->joint[1].position < -0.005f)
                 Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[1] = 1;
             else Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[1] = 0;
+
+            /* [右大腿] 安全位置: position 在 [0.01, 0.20] 范围内 */
             if (in->joint[2].position < 0.20f && in->joint[2].position > 0.01f)
                 Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[2] = 1;
             else Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[2] = 0;
+
+            /* [右小腿] 安全位置: position > 0 (与左小腿对称,方向相反) */
             if (in->joint[3].position > -0.0f)
                 Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[3] = 1;
             else Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[3] = 0;
 
+            /* 🐣 步骤2b: 当 4 个标志全部为 1 → 初始化完成！
+               把 4 个 bool 值加起来,和为 4 就是全部到位 */
             if (Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[0] +
                 Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[1] +
                 Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[2] +
@@ -75,15 +180,20 @@ void Mode_Update(Control_Info_Typedef *Control_Info, const control_input_snapsho
             } else {
                 Control_Info->Init.Joint_Init.IF_Joint_Init = 0;
             }
+            /* 初始化期间,底盘位置清零(防止上一周期的累积误差) */
             Control_Info->L_Leg_Info.Measure.Chassis_Position = 0;
             Control_Info->R_Leg_Info.Measure.Chassis_Position = 0;
         } else if (Control_Info->Init.Joint_Init.IF_Joint_Init == 1) {
+            /* 🐣 步骤2c: 初始化完成 → 进入平衡模式!
+               CHASSIS_BALANCE 标志一旦置 1, LQR 控制回路正式开始工作 */
             Control_Info->Chassis_Situation = CHASSIS_BALANCE;
             Control_Info->L_Leg_Info.Measure.Chassis_Position = 0;
             Control_Info->R_Leg_Info.Measure.Chassis_Position = 0;
         }
     }
 
+    /* 🐣 步骤3: 如果不再允许初始化 → 清零所有初始化标志
+       这是"安全退出"逻辑,保证状态机不会卡在中间状态 */
     if (Control_Info->Init.IF_Begin_Init == 0 && Control_Info->Chassis_Situation == CHASSIS_WEAK) {
         Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[0] = 0;
         Control_Info->Init.Joint_Init.IF_Joint_Reduction_Flag[1] = 0;

--- a/Application/Task/Src/sensor_fusion.c
+++ b/Application/Task/Src/sensor_fusion.c
@@ -1,51 +1,122 @@
 /**
   ******************************************************************************
   * @file           : sensor_fusion.c
-  * @brief          : IMU + wheel odometry sensor fusion
+  * @brief          : 传感器融合 — 把多个不完美的传感器数据"揉"出一个可靠结果
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   机器人有两个信息来源: IMU(惯性传感器,给你倾角/角速度/加速度)和
+  *   轮速计(电机转速,给你底盘速度)。但两者都不完美:
+  *   - IMU 加速度有噪声,直接积分两次会漂到天上去
+  *   - 轮速计有打滑(比如轮子空转时,读数是假的)
+  *   所以这个文件做的事情就是"两个人说速度是多少,我取个加权平均"。
+  *
+  * 【核心职责】
+  *   1. 从 IMU 读取倾角 Phi 和角速度 Phi_dot (左右腿各一份)
+  *   2. 从轮速计读取 RPM,转换成线速度,减去机身自转+腿部摆动
+  *   3. "一阶滞后滤波": 0.8×预测值 + 0.2×测量值 = 融合速度
+  *   4. 计算底盘加速度 Accel (用于速度预测)
+  *   5. CHASSIS_WEAK 状态下清零所有状态量(防止错误控制)
+  *
+  * 【前置知识】
+  *   - 互补滤波的思想: 相信低频的轮速计(长期准),相信高频的IMU(短期快)
+  *   - 融合公式: Fusion = α×Predict + (1-α)×Measure, α=0.8
+  *     α 越大,越"懒",响应慢但平滑; α 越小,越"敏感",响应快但噪声大
+  *
   ******************************************************************************
   */
 
 #include "sensor_fusion.h"
 #include "arm_math.h"
 
+/* [重力加速度] (m/s²) | 地球重力常数,用于修正 IMU 加速度读数
+   🐣 IMU 测到的加速度 = 真实运动加速度 + 重力分量。要扣除重力才知道"真速度"。 */
 #define GravityAccel 9.81f
 
 void SensorFusion_Measure_Update(Control_Info_Typedef *Control_Info,
                                   const control_input_snapshot_t *in)
 {
-    /* --- 共享 IMU 数据 (避免重复读取) --- */
+    /* ====== 共享 IMU 数据提取 ======
+       🐣 Phi 是"机身倾角"——机器人前后倒了多少度。
+       左右腿站在同一块机身上,所以 Phi 和 Phi_dot 对两条腿是一样的。
+       这里提到外面,避免重复读两次 IMU。 */
+    /* [机身倾角] (弧度 rad) | 范围: [-π/6, π/6] | 正值=向后仰
+       🐣 = -IMU测的Pitch角 - 安装补偿角。负号是因为IMU方向跟控制坐标系可能反了 */
     float phi_shared     = -in->ins.Angle[2] - Control_Info->L_Leg_Info.Phi_Comp_Angle;
+    /* [机身倾角速度] (弧度/秒 rad/s) | 范围: [-5, 5] | 正值=正在向后倒 */
     float phi_dot_shared = -in->ins.Gyro[0];
 
-    /* --- 左腿姿态 --- */
+    /* ====== LEFT LEG 左腿姿态 ====== */
+
     Control_Info->L_Leg_Info.Measure.Phi     = phi_shared;
     Control_Info->L_Leg_Info.Measure.Phi_dot = phi_dot_shared;
+
+    /* [虚拟腿倾角 Theta] (弧度 rad) | 范围: [-π/4, π/4]
+       🐣 Theta = (地平线方向) - 虚拟腿角度 - 机身倾斜
+       = (PI/2 - Sip_Leg_Angle) - Phi
+       这就是 LQR 状态向量 X[0] 的测量值——"虚拟腿偏离竖直方向多少"。 */
     Control_Info->L_Leg_Info.Measure.Theta   = ((PI/2) - Control_Info->L_Leg_Info.Sip_Leg_Angle) - Control_Info->L_Leg_Info.Measure.Phi;
+
+    /* [虚拟腿倾角速度] (弧度/秒 rad/s)
+       🐣 把 J 点的 X/Y 方向线速度,投影到"垂直于虚拟腿"的方向上,
+       再除以虚拟腿长,得到角速度。这叫"坐标投影+归一化"。 */
     Control_Info->L_Leg_Info.Measure.Theta_dot = (Control_Info->L_Leg_Info.X_J_Dot * arm_cos_f32(-Control_Info->L_Leg_Info.Measure.Theta)
                                                 + Control_Info->L_Leg_Info.Y_J_Dot * arm_sin_f32(-Control_Info->L_Leg_Info.Measure.Theta))
                                                / Control_Info->L_Leg_Info.Sip_Leg_Length;
 
-    /* --- 右腿姿态 --- */
+    /* ====== RIGHT LEG 右腿姿态 ====== */
     Control_Info->R_Leg_Info.Measure.Phi     = phi_shared;
     Control_Info->R_Leg_Info.Measure.Phi_dot = phi_dot_shared;
+
+    /* 🐣 右腿的虚拟腿倾角公式跟左腿符号略有不同,因为坐标系定义差异 */
     Control_Info->R_Leg_Info.Measure.Theta   = (Control_Info->R_Leg_Info.Sip_Leg_Angle - (PI/2)) - Control_Info->R_Leg_Info.Measure.Phi;
+
     Control_Info->R_Leg_Info.Measure.Theta_dot = (-Control_Info->R_Leg_Info.X_J_Dot * arm_cos_f32(-Control_Info->R_Leg_Info.Measure.Theta)
                                                  + Control_Info->R_Leg_Info.Y_J_Dot * arm_sin_f32(-Control_Info->R_Leg_Info.Measure.Theta))
                                                 / Control_Info->R_Leg_Info.Sip_Leg_Length;
 
-    /* --- 左腿轮速融合 --- */
+    /* ====== LEFT LEG 左腿轮速融合 ====== */
+
+    /* 🐣 第1步: RPM → 角速度 (弧度/秒)
+       RPM×(π/30) = 弧度/秒, 再÷15 = 减速比(电机转15圈轮子转1圈) */
     Control_Info->L_Leg_Info.Velocity.Wheel = in->wheel[0].velocity * (PI / 30.f) / 15.f;
+
+    /* 🐣 第2步: 补偿后的真实轮速
+       W = 轮子转速 - 机身旋转速度 + 腿部摆动速度
+       "如果轮子在转,但转是因为机身整体在转,那不算真实移动" */
     Control_Info->L_Leg_Info.Velocity.W     = (Control_Info->L_Leg_Info.Velocity.Wheel
                                               - Control_Info->L_Leg_Info.Measure.Phi_dot
                                               + Control_Info->L_Leg_Info.Measure.Theta_dot);
+
+    /* 🐣 第3步: 角速度 → 线速度
+       X = W × r, 轮半径 0.055m, 单位: m/s */
     Control_Info->L_Leg_Info.Velocity.X     = Control_Info->L_Leg_Info.Velocity.W * 0.055f;
+
+    /* 🐣 第4步: 腿长变化率
+       只取 Y_J_Dot 在 Theta 方向上的投影,因为"腿长变化"只跟垂直方向有关 */
     Control_Info->L_Leg_Info.Sip_Leg_Length_dot = Control_Info->L_Leg_Info.Y_J_Dot * arm_cos_f32(Control_Info->L_Leg_Info.Measure.Theta);
+
+    /* 🐣 第5步: Body = 原始线速度(基础版,不含运动学高级补偿) */
     Control_Info->L_Leg_Info.Velocity.Body  = Control_Info->L_Leg_Info.Velocity.X;
+
+    /* 🐣 第6步: 预测速度 = 上一周期的融合速度 + 加速度×Δt
+       Δt = 0.001s (1ms周期), Accel 来自 IMU 加速度(扣除重力后)
+       "如果我知道上一瞬间跑多快,也知道加速度,就能猜出现在应该跑多快" */
     Control_Info->L_Leg_Info.Predict_Velocity = Control_Info->L_Leg_Info.Velocity.Fusion + Control_Info->Accel * 0.001f;
+
+    /* 🐣 第7步: 融合速度 (核心公式!)
+       Fusion = 0.8 × Predict + 0.2 × Body
+       - 0.8 权重给"我觉得",相信自己的预测(平滑,抗噪声)
+       - 0.2 权重给"我看到",相信测量(修正累积误差)
+       这就是一阶滞后滤波器 —— 机器人控制中最常见的数据融合方式 */
     Control_Info->L_Leg_Info.Velocity.Fusion  = Control_Info->L_Leg_Info.Velocity.Predict * 0.8f + Control_Info->L_Leg_Info.Velocity.Body * 0.2f;
+
+    /* 最终: 融合速度 → 赋值给底盘速度测量值 (LQR 状态向量 X[3] 的测量值) */
     Control_Info->L_Leg_Info.Measure.Chassis_Velocity = Control_Info->L_Leg_Info.Velocity.Fusion;
 
-    /* --- 右腿轮速融合 --- */
+    /* ====== RIGHT LEG 右腿轮速融合 (原理同上,注意右轮极性取反) ====== */
+    /* ⚠ 右轮 RPM 取反: 因为左右轮镜像安装,同方向旋转时 RPM 符号相反 */
     Control_Info->R_Leg_Info.Velocity.Wheel = -in->wheel[1].velocity * (3.141593f / 30.f) / 15.f;
     Control_Info->R_Leg_Info.Velocity.W     = (Control_Info->R_Leg_Info.Velocity.Wheel
                                               - Control_Info->R_Leg_Info.Measure.Phi_dot
@@ -57,10 +128,18 @@ void SensorFusion_Measure_Update(Control_Info_Typedef *Control_Info,
     Control_Info->R_Leg_Info.Velocity.Fusion  = 0.8f * Control_Info->R_Leg_Info.Velocity.Predict + Control_Info->R_Leg_Info.Velocity.Body * 0.2f;
     Control_Info->R_Leg_Info.Measure.Chassis_Velocity = Control_Info->R_Leg_Info.Velocity.Fusion;
 
-    /* --- 底盘速度与位置 --- */
+    /* ====== 底盘总体速度与位置 ====== */
+
+    /* 综合底盘速度 = 左右腿速度的平均值
+       🐣 正常时两腿速度应该差不多,取平均能减少测量误差 */
     Control_Info->Chassis_Velocity = (Control_Info->L_Leg_Info.Measure.Chassis_Velocity + Control_Info->R_Leg_Info.Measure.Chassis_Velocity) / 2.f;
 
+    /* 🐣 位置更新逻辑:
+       - 如果目标速度为0(停止/定速模式) → 积分速度得到位置
+       - 如果目标速度非0(正在移动)   → 位置归零(位置环不工作,只控速度)
+       为什么？因为"我要走到正前方2米"这个功能还在开发,目前位置只用来自平衡 */
     if (Control_Info->Target_Velocity == 0) {
+        /* 位置 = 位置 + 速度 × Δt (Δt = 0.001s) */
         Control_Info->L_Leg_Info.Measure.Chassis_Position += Control_Info->Chassis_Velocity * 0.001f;
         Control_Info->R_Leg_Info.Measure.Chassis_Position += Control_Info->Chassis_Velocity * 0.001f;
     } else {
@@ -68,12 +147,27 @@ void SensorFusion_Measure_Update(Control_Info_Typedef *Control_Info,
         Control_Info->R_Leg_Info.Measure.Chassis_Position = 0;
     }
 
-    /* --- 底盘加速度 --- */
+    /* ====== 底盘加速度计算 ======
+       🐣 基本物理公式: IMU测的加速度 = 运动加速度 + 重力分量 + 向心加速度
+       我们要的是"运动加速度",所以要扣除重力和向心项:
+
+       Accel = [(-a_y + ω_z²×r - g×sinΦ)×cosΦ] + [(a_z - g×cosΦ)×sinΦ]
+
+       其中:
+       - -a_y: Y轴加速度 (前后方向)
+       - ω_z²×0.155: 向心加速度 (0.155m 是 IMU 到旋转中心的距离)
+       - g×sinΦ: 重力在前后方向的分量 (倾斜时重力会"拽着你往前滑")
+       - a_z - g×cosΦ: Z轴加速度扣除重力后有效分量
+       - 乘以 cosΦ/sinΦ: 投影到水平方向 */
     Control_Info->Accel = (float)((-in->ins.Accel[1] + powf(in->ins.Gyro[2], 2) * 0.155f)
                           - GravityAccel * arm_sin_f32(-in->ins.Angle[2])) * arm_cos_f32(-in->ins.Angle[2])
                         + (in->ins.Accel[2] - GravityAccel * arm_cos_f32(-in->ins.Angle[2])) * arm_sin_f32(-in->ins.Angle[2]);
 
-    /* --- CHASSIS_WEAK 状态清零 --- */
+    /* ====== CHASSIS_WEAK 状态安全保护 ======
+       🐣 如果底盘处于"虚弱"状态(没初始化好/关机了),所有状态量强行清零。
+       如果不这样做,残存的错误状态会通过 LQR 产生错误输出,
+       可能在下次启动时导致机器人突然猛烈动作——这是非常危险的！
+       所以这个 if 块不是可选的,而是"安全气囊"。 */
     if (Control_Info->Chassis_Situation == CHASSIS_WEAK) {
         Control_Info->L_Leg_Info.Measure.Phi = 0;
         Control_Info->L_Leg_Info.Measure.Phi_dot = 0;

--- a/Application/Task/Src/vmc_kinematics.c
+++ b/Application/Task/Src/vmc_kinematics.c
@@ -1,25 +1,65 @@
 /**
   ******************************************************************************
   * @file           : vmc_kinematics.c
-  * @brief          : VMC forward kinematics and torque mapping
+  * @brief          : VMC 运动学 — 把两条复杂的连杆腿变成两根简单的"棍子"
+  *
+  * ====== 🐣 新手必读 ======
+  *
+  * 【这个文件在干什么？】
+  *   机器人的真实腿有2个关节: 大腿(Thigh)绕髋转,小腿(Calf)绕膝转。
+  *   如果你直接基于这两个角度来做平衡控制,数学会极其复杂。
+  *   所以这个文件做了三件事:
+  *   1. 把"两个角度"通过正运动学公式变成"一根虚拟棍子"(长度L₀+倾角φ₀)
+  *   2. 从电机力矩反馈反算出虚拟腿受的外力 F 和扭矩 Tp (逆动力学)
+  *   3. 最后一步把算好的 F/Tp 通过雅可比矩阵"翻译"回4个关节电机的力矩
+  *
+  * 【核心职责】
+  *   1. Joint_Angle_Offset: 电机角度 → 大腿/小腿摆角 (坐标系映射)
+  *   2. VMC_Calculate:      正运动学 → 虚拟腿长 L₀ + 倾角 φ₀
+  *   3. Measure_F_Tp:       逆动力学 → 虚拟力 F + 扭矩 Tp + 着地检测
+  *   4. Joint_Tourgue:      雅可比 → 虚拟F/Tp → 4个真实关节力矩
+  *
+  * 【前置知识】
+  *   - 连杆正运动学: θ → (x,y) 的几何转换
+  *   - 雅可比矩阵: 虚拟力到关节力矩的"翻译器"
+  *   - arm_sin_f32/arm_cos_f32: ARM CMSIS-DSP 库的高速三角函数
+  *
   ******************************************************************************
   */
 
 #include "vmc_kinematics.h"
 #include "arm_math.h"
 
+/**
+ * VMC_Joint_Angle_Offset — 坐标系映射
+ *
+ * 🐣 电机汇报的"位置"和算法需要的"摆角"之间需要转换:
+ *   - 左小腿: 电机角度 = 小腿摆角 (同方向)
+ *   - 左大腿: 电机角度 + PI = 大腿摆角 (电机方向和腿方向差180°)
+ *   - 右腿: 类似于左腿,但映射关系不同(因为右侧电机朝向镜像)
+ */
 void VMC_Joint_Angle_Offset(Control_Info_Typedef *Control_Info, const control_input_snapshot_t *in)
 {
-    /* 左腿 */
+    /* ====== LEFT LEG ====== */
+    /* [左小腿摆角] (弧度 rad) | 电机0位置直接映射 */
     Control_Info->L_Leg_Info.Biased.Calf_Angle      = in->joint[0].position;
+
+    /* [左大腿摆角] (弧度 rad) | PI + 电机1位置
+       🐣 为什么加PI? 因为电机装在腿后面,转轴方向和腿摆角方向差了180° */
     Control_Info->L_Leg_Info.Biased.Thigh_Angle     = PI + in->joint[1].position;
+
+    /* [大腿/小腿角速度] (弧度/秒 rad/s) | 直接映射 */
     Control_Info->L_Leg_Info.Biased.Thigh_Angle_Dot = in->joint[1].velocity;
     Control_Info->L_Leg_Info.Biased.Calf_Angle_Dot  = in->joint[0].velocity;
+
+    /* [大腿/小腿力矩反馈] (N·m) | 电机实际输出的扭矩
+       🐣 用于逆动力学反算腿受的外力 */
     Control_Info->L_Leg_Info.Biased.T_Thigh         = in->joint[1].torque;
     Control_Info->L_Leg_Info.Biased.T_Calf          = in->joint[0].torque;
 
-    /* 右腿 */
+    /* ====== RIGHT LEG ====== */
     Control_Info->R_Leg_Info.Biased.Thigh_Angle     = in->joint[2].position;
+    /* 🐣 右小腿: PI + 电机3位置 (同左腿映射) */
     Control_Info->R_Leg_Info.Biased.Calf_Angle      = PI + in->joint[3].position;
     Control_Info->R_Leg_Info.Biased.Thigh_Angle_Dot = in->joint[2].velocity;
     Control_Info->R_Leg_Info.Biased.Calf_Angle_Dot  = in->joint[3].velocity;
@@ -27,24 +67,70 @@ void VMC_Joint_Angle_Offset(Control_Info_Typedef *Control_Info, const control_in
     Control_Info->R_Leg_Info.Biased.T_Calf          = in->joint[3].torque;
 }
 
+/**
+ * VMC_Calculate — VMC 正运动学 (Virtual Model Control)
+ *
+ * 🐣 这是整个项目中最核心的数学步骤！
+ *   目标: 把 2 个关节角度(θ₁=小腿, θ₂=大腿) 映射为 2 个简化参数(L₀=虚拟腿长, φ₀=虚拟摆角)
+ *
+ *   ============ 数学公式推导(不需要背) ============
+ *   给定: θ₁=小腿摆角, θ₂=大腿摆角,
+ *         a=AD(小腿连杆长), b=AH(大腿连杆长), K=AD/AH
+ *
+ *   中间变量:
+ *     M = (θ₁ - θ₂)/2          // 夹角半差值
+ *     N = (θ₁ + θ₂)/2          // 夹角半和值
+ *     S = √(b² - a²·sin²(M))   // 勾股定理的推广
+ *     t = a·cos(M) + S         // 脚底到髋关节的水平投影
+ *     A = a·t·sin(M) / S       // 雅可比转换系数(力矩翻译器)
+ *
+ *   最终结果:
+ *     φ₀ = N                   // 虚拟腿的摆角 = 两关节角度的平均值
+ *     L₀ = t / K              // 虚拟腿长度 = 几何关系÷杆长比
+ *
+ *   🐣 通俗理解: "大腿和小腿各弯多少" → "从屁股到脚底,等效于一根多长的棍子、倾多少度"
+ */
 void VMC_Calculate(Control_Info_Typedef *Control_Info)
 {
-    /* 左腿 VMC 正运动学 — 中间变量使用栈局部变量 */
-    float L_a = Control_Info->L_Leg_Info.Biased.L_Calf_Link;
-    float L_b = Control_Info->L_Leg_Info.Biased.L_Thigh_Link;
+    /* ====== LEFT LEG 左腿 VMC 正运动学 ====== */
+
+    /* 🐣 第1步: 取出机械参数,赋给局部变量 (不在结构体里占内存) */
+    float L_a = Control_Info->L_Leg_Info.Biased.L_Calf_Link;   /* a = 小腿连杆长度 AD */
+    float L_b = Control_Info->L_Leg_Info.Biased.L_Thigh_Link;  /* b = 大腿连杆长度 AH */
+
+    /* M = -(小腿角 - 大腿角)/2
+       🐣 负号是因为左右腿的关节角度定义方向不同 */
     float L_M = -(Control_Info->L_Leg_Info.Biased.Calf_Angle - Control_Info->L_Leg_Info.Biased.Thigh_Angle) / 2.f;
+
+    /* N = (小腿角 + 大腿角)/2
+       🐣 两个角度的"均值方向",就是最终的虚拟腿方向 */
     float L_N = (Control_Info->L_Leg_Info.Biased.Calf_Angle + Control_Info->L_Leg_Info.Biased.Thigh_Angle) / 2.f;
+
+    /* S_Radicand = b² - a²·sin²(M)
+       🐣 这一步在算"在弯曲这么多时,连杆的长度投影还剩多少" */
     float L_S_Radicand = L_b * L_b - L_a * L_a * arm_sin_f32(L_M) * arm_sin_f32(L_M);
+
     float L_S;
     arm_sqrt_f32(L_S_Radicand, &L_S);
-    if (L_S < 1e-6f) L_S = 1e-6f;  /* 防止除零 */
+    /* 🔧 安全保护: 如果 S 接近零(浮点误差),强行设一个极小值,防止后面除零崩溃 */
+    if (L_S < 1e-6f) L_S = 1e-6f;
+
+    /* t = a·cos(M) + S
+       🐣 这是"脚到髋关节的水平距离",也是虚拟腿长的分子 */
     float L_t = L_a * arm_cos_f32(L_M) + L_S;
+
+    /* A = a·t·sin(M) / S
+       🐣 这个 A 不是角度,是雅可比转换系数！
+       后面 Joint_Tourgue_Calculate 中会用 A/K 把虚拟力 F 翻译成关节扭矩 */
     float L_A = (L_a * L_t * arm_sin_f32(L_M)) / L_S;
 
-    Control_Info->L_Leg_Info.A = L_A;
-    Control_Info->L_Leg_Info.Sip_Leg_Angle  = L_N;
-    Control_Info->L_Leg_Info.Sip_Leg_Length = L_t / Control_Info->L_Leg_Info.Biased.K;
+    /* 🐣 把局部计算结果写回结构体 */
+    Control_Info->L_Leg_Info.A = L_A;                     /* 雅可比系数 */
+    Control_Info->L_Leg_Info.Sip_Leg_Angle  = L_N;       /* φ₀ = N */
+    Control_Info->L_Leg_Info.Sip_Leg_Length = L_t / Control_Info->L_Leg_Info.Biased.K;  /* L₀ = t/K */
 
+    /* 🐣 J 点速度: X_J_Dot = (A×cosN×(ω₁-ω₂) - t×sinN×(ω₁+ω₂)) / (2·K)
+       这是"轮子轴心的水平和垂直速度",用于传感器融合中的速度补偿 */
     Control_Info->L_Leg_Info.X_J_Dot = (L_A * arm_cos_f32(L_N) * (Control_Info->L_Leg_Info.Biased.Thigh_Angle_Dot - Control_Info->L_Leg_Info.Biased.Calf_Angle_Dot)
                                       - L_t * arm_sin_f32(L_N) * (Control_Info->L_Leg_Info.Biased.Thigh_Angle_Dot + Control_Info->L_Leg_Info.Biased.Calf_Angle_Dot))
                                      / (2.f * Control_Info->L_Leg_Info.Biased.K);
@@ -52,15 +138,16 @@ void VMC_Calculate(Control_Info_Typedef *Control_Info)
                                       + L_t * arm_cos_f32(L_N) * (Control_Info->L_Leg_Info.Biased.Thigh_Angle_Dot + Control_Info->L_Leg_Info.Biased.Calf_Angle_Dot))
                                      / (2.f * Control_Info->L_Leg_Info.Biased.K);
 
-    /* 右腿 VMC 正运动学 */
+    /* ====== RIGHT LEG 右腿 VMC 正运动学 (公式同上,变量独立) ====== */
     float R_a = Control_Info->R_Leg_Info.Biased.L_Calf_Link;
     float R_b = Control_Info->R_Leg_Info.Biased.L_Thigh_Link;
+    /* 🐣 右腿的 M 公式中 Thigh 和 Calf 顺序跟左腿不一样 */
     float R_M = -(Control_Info->R_Leg_Info.Biased.Thigh_Angle - Control_Info->R_Leg_Info.Biased.Calf_Angle) / 2.f;
     float R_N = (Control_Info->R_Leg_Info.Biased.Calf_Angle + Control_Info->R_Leg_Info.Biased.Thigh_Angle) / 2.f;
     float R_S_Radicand = R_b * R_b - R_a * R_a * arm_sin_f32(R_M) * arm_sin_f32(R_M);
     float R_S;
     arm_sqrt_f32(R_S_Radicand, &R_S);
-    if (R_S < 1e-6f) R_S = 1e-6f;  /* 防止除零 */
+    if (R_S < 1e-6f) R_S = 1e-6f;
     float R_t = R_a * arm_cos_f32(R_M) + R_S;
     float R_A = (R_a * R_t * arm_sin_f32(R_M)) / R_S;
 
@@ -76,29 +163,57 @@ void VMC_Calculate(Control_Info_Typedef *Control_Info)
                                      / (2.f * Control_Info->R_Leg_Info.Biased.K);
 }
 
+/**
+ * VMC_Measure_F_Tp_Calculate — 逆动力学 + 着地检测
+ *
+ * 🐣 从电机力矩反馈反推虚拟腿受的外力,并判断腿是否接触地面。
+ *
+ *   公式:
+ *     F  = K×(T_calf - T_thigh) / A     (虚拟推力)
+ *     Tp = T_thigh + T_calf              (虚拟扭矩)
+ *     FN = F×cos(Theta) + (Tp×sin(Theta))/L₀  (地面法向支持力)
+ *
+ *   离地判定: FN < 22N → Support.Flag = 1 (在空中)
+ *   ⚠ 为什么是 22N？因为机器人自重约 200N(20kg),
+ *   两条腿各承担约 100N。如果 FN < 22N,说明这条腿几乎没受力→离地了。
+ */
 void VMC_Measure_F_Tp_Calculate(Control_Info_Typedef *Control_Info)
 {
-    /* 左腿 */
+    /* ====== LEFT LEG ====== */
+    /* F = K×(T_Calf - T_Thigh) / A
+       🐣 这个公式的反直觉之处: 小腿力矩减大腿力矩,除以雅可比系数 = 虚拟推力
+       因为小腿和大腿的力矩方向相反(一个伸一个收),差值才是净效果 */
     Control_Info->L_Leg_Info.Measure.F  = (Control_Info->L_Leg_Info.Biased.K * (Control_Info->L_Leg_Info.Biased.T_Calf - Control_Info->L_Leg_Info.Biased.T_Thigh)) / Control_Info->L_Leg_Info.A;
+    /* Tp = T_Thigh + T_Calf
+       🐣 扭矩 = 两个力矩的和,因为两个电机输出扭矩方向一致时叠加 */
     Control_Info->L_Leg_Info.Measure.Tp = (Control_Info->L_Leg_Info.Biased.T_Thigh + Control_Info->L_Leg_Info.Biased.T_Calf);
-    /* 右腿 */
+
+    /* ====== RIGHT LEG ====== */
+    /* ⚠ 右腿公式: T_Thigh - T_Calf (跟左腿符号相反,因为左右腿坐标系镜像) */
     Control_Info->R_Leg_Info.Measure.F  = (Control_Info->R_Leg_Info.Biased.K * (Control_Info->R_Leg_Info.Biased.T_Thigh - Control_Info->R_Leg_Info.Biased.T_Calf)) / Control_Info->R_Leg_Info.A;
     Control_Info->R_Leg_Info.Measure.Tp = (Control_Info->R_Leg_Info.Biased.T_Thigh + Control_Info->R_Leg_Info.Biased.T_Calf);
 
+    /* ====== 着地检测 ====== */
     if (Control_Info->Chassis_Situation == CHASSIS_BALANCE) {
-        Control_Info->L_Leg_Info.Measure.Tp = Control_Info->L_Leg_Info.Measure.Tp;
+        /* 仅在平衡状态下进行着地检测 */
+
+        /* 地面支持力 FN = F×cos(Theta) + (Tp×sin(Theta))/L₀
+           🐣 把虚拟腿的推力和扭矩投影到"垂直地面"方向,得到地面对轮子的反力 */
         Control_Info->L_Leg_Info.Support.FN = Control_Info->L_Leg_Info.Measure.F * arm_cos_f32(Control_Info->L_Leg_Info.Measure.Theta)
                                             + ((Control_Info->L_Leg_Info.Measure.Tp * arm_sin_f32(Control_Info->L_Leg_Info.Measure.Theta))
                                                / Control_Info->L_Leg_Info.Sip_Leg_Length);
 
-        Control_Info->R_Leg_Info.Measure.Tp = Control_Info->R_Leg_Info.Measure.Tp;
+        /* 右腿同理,⚠ 注意有一个额外的负号(与左右腿坐标系有关) */
         Control_Info->R_Leg_Info.Support.FN = Control_Info->R_Leg_Info.Measure.F * arm_cos_f32(Control_Info->R_Leg_Info.Measure.Theta)
                                             + (-(Control_Info->R_Leg_Info.Measure.Tp * arm_sin_f32(Control_Info->R_Leg_Info.Measure.Theta))
                                                / Control_Info->R_Leg_Info.Sip_Leg_Length);
 
+        /* 🐣 判断着地: FN < 22N → 腿在空中
+           这个阈值是根据"半车重约100N,着地时FN应在50~150N之间"设定的 */
         Control_Info->L_Leg_Info.Support.Flag = (Control_Info->L_Leg_Info.Support.FN < 22.f);
         Control_Info->R_Leg_Info.Support.Flag = (Control_Info->R_Leg_Info.Support.FN < 22.f);
     } else {
+        /* 非平衡状态下,着地检测无效,全部清零 */
         Control_Info->L_Leg_Info.Support.Flag = 0;
         Control_Info->R_Leg_Info.Support.Flag = 0;
         Control_Info->L_Leg_Info.Support.FN   = 100.f;
@@ -106,23 +221,52 @@ void VMC_Measure_F_Tp_Calculate(Control_Info_Typedef *Control_Info)
     }
 }
 
+/**
+ * VMC_Joint_Tourgue_Calculate — 雅可比矩阵转换 + 输出限幅
+ *
+ * 🐣 这是控制流水线的最后一步——把虚拟力F/扭矩Tp "翻译"回4个关节电机的力矩。
+ *
+ *   公式(左腿):
+ *     T2(小腿) = (A/K) × F + Tp/2
+ *     T1(大腿) = (-A/K) × F + Tp/2
+ *
+ *   为什么(A/K)前面有个负号？因为大腿和小腿的力矩方向相反——
+ *   想给脚底一个向下的推力,大腿要"伸直"、小腿要"弯曲"。
+ *
+ *   ⚠ 限幅保护: 每个关节力矩被(-15, 15) N·m 夹住,防止烧电机。
+ *   轮子电流也被(-10000, 10000) mA 夹住。
+ */
 void VMC_Joint_Tourgue_Calculate(Control_Info_Typedef *Control_Info)
 {
+    /* [力矩上限] (N·m) | 电机能安全输出的最大扭矩 */
     float Tourgue_max = 15.f;
+    /* [电流上限] (mA) | 驱动器能安全输出的最大电流 */
     float Current_max = 10000;
 
-    /* 左腿: T2(小腿)=A/K*F + Tp/2, T1(大腿)=-A/K*F + Tp/2 */
+    /* ====== LEFT LEG ====== */
+    /* T2(小腿) = (A/K)×F + Tp/2
+       🐣 左小腿=0号电机, T2对应小腿力矩 */
     Control_Info->L_Leg_Info.SendValue.T_Calf  = (Control_Info->L_Leg_Info.A * Control_Info->L_Leg_Info.F) / Control_Info->L_Leg_Info.Biased.K + (Control_Info->L_Leg_Info.Tp / 2.0f);
+    /* T1(大腿) = (-A/K)×F + Tp/2
+       🐣 左大腿=1号电机,注意前面有负号 */
     Control_Info->L_Leg_Info.SendValue.T_Thigh = (-Control_Info->L_Leg_Info.A * Control_Info->L_Leg_Info.F) / Control_Info->L_Leg_Info.Biased.K + (Control_Info->L_Leg_Info.Tp / 2.0f);
 
-    /* 右腿: T2(大腿)=A/K*F + Tp/2, T1(小腿)=-A/K*F + Tp/2 */
+    /* ====== RIGHT LEG ====== */
+    /* ⚠ 右腿的映射关系和左腿略有不同:
+       T2(大腿) = (A/K)×F + Tp/2  → 2号电机
+       T1(小腿) = (-A/K)×F + Tp/2 → 3号电机 */
     Control_Info->R_Leg_Info.SendValue.T_Thigh = (Control_Info->R_Leg_Info.A * Control_Info->R_Leg_Info.F) / Control_Info->R_Leg_Info.Biased.K + (Control_Info->R_Leg_Info.Tp / 2.0f);
     Control_Info->R_Leg_Info.SendValue.T_Calf  = (-Control_Info->R_Leg_Info.A * Control_Info->R_Leg_Info.F) / Control_Info->R_Leg_Info.Biased.K + (Control_Info->R_Leg_Info.Tp / 2.0f);
 
-    /* 轮子力矩 → 电流转换 */
+    /* ====== 轮子力矩 → 电流转换 ====== */
+    /* 🐣 驱动轮使用"电流模式"控制,单位换算: 力矩(N·m) × 1200 ≈ 电流(mA)
+       右轮取反: 因为左右轮镜像安装,同时正转方向相反 */
     Control_Info->L_Leg_Info.SendValue.Current = (int16_t)(Control_Info->L_Leg_Info.T * 1200.f);
     Control_Info->R_Leg_Info.SendValue.Current = (int16_t)(-Control_Info->R_Leg_Info.T * 1200.f);
 
+    /* ====== ⚠ 限幅保护 (安全气囊!) ====== */
+    /* 🐣 如果不加这些限幅,异常情况下可能输出 ±1000N·m 的力矩,
+       电机会瞬间过流烧毁。限幅后保证在安全范围内。 */
     VAL_LIMIT(Control_Info->L_Leg_Info.SendValue.Current, -Current_max, Current_max);
     VAL_LIMIT(Control_Info->R_Leg_Info.SendValue.Current, -Current_max, Current_max);
 


### PR DESCRIPTION
## 为 10 个核心文件添加"保姆级"新手友好注释

每个文件遵循 4 部分注释规范:

### 📋 注释规范
1. **文件头部导读**: 大白话总结 + 核心职责 + 前置知识
2. **变量注释**: 物理意义 + 量纲/单位 + 正常范围 + 🐣 通俗解释
3. **算法解释**: 公式原型 + 物理映射 + 分步注释
4. **逐行意图**: 解释"为什么这样做"而非"代码做什么",标注安全风险(`⚠`)

### 📁 涉及文件 (+1341/-490 行)

| 文件 | 改动 | 亮点 |
|------|------|------|
| `control_io.h` | +160/-84 | "海关"比喻, 每个结构体字段带 🐣 解释 |
| `Control_Task.c` | +193/-0 | 16步流水线每步都有注释, 编排器模式讲解 |
| `mode_state_machine.c` | +116/-9 | PID_PARAM 宏 + 初始化状态机逻辑图 |
| `vmc_kinematics.c` | +182/-9 | 完整数学公式推导 + "为什么A不是角度" |
| `lqr_controller.c` | +132/-10 | 增益调度原理 + K11~K26 系数说明 |
| `chassis_control.c` | +119/-9 | 四个独立控制通道的物理直觉 |
| `sensor_fusion.c` | +112/-9 | "0.8×预测+0.2×测量"为什么是这个系数 |
| `CAN_Task.c` | +198/-88 | FDCAN 协议 + 初始化/运行/关机三状态 |
| `control_io.c` | +77/-12 | 唯一能碰硬件的"海关"实现 |
| `INS_Task.c` | +312/-260 | 四元数EKF + 偏航总圈数维护逻辑 |